### PR TITLE
Failing tests for #16

### DIFF
--- a/tests/Set/DoctrineORM29Set/Fixture/index.php.inc
+++ b/tests/Set/DoctrineORM29Set/Fixture/index.php.inc
@@ -8,8 +8,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Index;
 
 /**
- * @Entity
- * @Index(name="search_idx", columns={"name", "c"})
+ * @Entity(indexes={@Index(name="search_idx", columns={"name", "c"})}]
  */
 class ECommerceProduct
 {

--- a/tests/Set/DoctrineORM29Set/Fixture/join_columns.php.inc
+++ b/tests/Set/DoctrineORM29Set/Fixture/join_columns.php.inc
@@ -25,7 +25,8 @@ use Doctrine\ORM\Mapping as ORM;
 
 class AnEntity
 {
-    #[\Doctrine\ORM\Mapping\JoinColumns(['(name="entity_id", referencedColumnName="id")', '(name="entity_type", referencedColumnName="entity_type")'])]
+    #[\Doctrine\ORM\Mapping\JoinColumn(name: 'entity_id', referencedColumnName: 'id')]
+    #[\Doctrine\ORM\Mapping\JoinColumn(name: 'entity_type', referencedColumnName: 'entity_type')]
     protected $page;
 }
 

--- a/tests/Set/DoctrineORM29Set/Fixture/unique_constraint.php.inc
+++ b/tests/Set/DoctrineORM29Set/Fixture/unique_constraint.php.inc
@@ -2,10 +2,11 @@
 
 namespace Rector\Doctrine\Tests\Set\DoctrineORM29Set\Fixture;
 
+use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\UniqueConstraint;
 
 /**
- * @UniqueConstraint(name="ean", columns={"ean"})
+ * @Entity(uniqueConstraints={@UniqueConstraint(name="ean", columns={"ean"})})
  */
 class ECommerceProduct
 {
@@ -17,8 +18,10 @@ class ECommerceProduct
 
 namespace Rector\Doctrine\Tests\Set\DoctrineORM29Set\Fixture;
 
+use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\UniqueConstraint;
 
+#[\Doctrine\ORM\Mapping\Entity]
 #[\Doctrine\ORM\Mapping\UniqueConstraint(name: 'ean', columns: ['ean'])]
 class ECommerceProduct
 {


### PR DESCRIPTION
See https://github.com/rectorphp/rector-doctrine/issues/16

`@UniqueConstraint` and `@Index` cannot be used on a class but must be used inside an annotation.

For attributes, that's the opposite, they must be declared on the class instead.

See docs https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/reference/attributes-reference.html#attrref_joincolumn