### PR TITLE
Convert `@EntityListeners` annotation to attribute

### DIFF
--- a/config/sets/doctrine-orm-29.php
+++ b/config/sets/doctrine-orm-29.php
@@ -80,6 +80,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     new AnnotationToAttribute('Doctrine\ORM\Mapping\PreUpdate', 'Doctrine\ORM\Mapping\PreUpdate'),
                     new AnnotationToAttribute('Doctrine\ORM\Mapping\Cache', 'Doctrine\ORM\Mapping\Cache'),
                     new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinColumns', 'Doctrine\ORM\Mapping\JoinColumns'),
+                    new AnnotationToAttribute('Doctrine\ORM\Mapping\EntityListeners', 'Doctrine\ORM\Mapping\EntityListeners'),
                 ]
             ),
         ]]);

--- a/tests/Set/DoctrineORM29Set/Fixture/entity_listeners.php.inc
+++ b/tests/Set/DoctrineORM29Set/Fixture/entity_listeners.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Set\DoctrineORM29Set\Fixture;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\EntityListeners;
+
+/**
+ * @Entity
+ * @EntityListeners({"App\MyListener"})
+ */
+class User
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Set\DoctrineORM29Set\Fixture;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\EntityListeners;
+
+#[\Doctrine\ORM\Mapping\Entity]
+#[\Doctrine\ORM\Mapping\EntityListeners(['App\MyListener'])]
+class User
+{
+}
+
+?>


### PR DESCRIPTION
Somehow there is a bug in `AnnotationToAttributeRector` that causes it not to work. No idea what it is.