### PR TITLE
Use IdentifierTypeNode instance for first parameter in DoctrineAnnotationTagValueNode

### DIFF
--- a/src/NodeFactory/EntityIdNodeFactory.php
+++ b/src/NodeFactory/EntityIdNodeFactory.php
@@ -41,13 +41,13 @@ final class EntityIdNodeFactory
         $phpDocTagNodes = [];
 
         $phpDocTagNodes[] = new SpacelessPhpDocTagNode('@ORM\Id', new DoctrineAnnotationTagValueNode(
-            'Doctrine\ORM\Mapping\Id',
+            new IdentifierTypeNode('Doctrine\ORM\Mapping\Id'),
             null,
             []
         ));
 
         $phpDocTagNodes[] = new SpacelessPhpDocTagNode('@ORM\Column', new DoctrineAnnotationTagValueNode(
-            'Doctrine\ORM\Mapping\Column',
+            new IdentifierTypeNode('Doctrine\ORM\Mapping\Column'),
             null,
             [
                 'type' => '"integer"',
@@ -55,7 +55,7 @@ final class EntityIdNodeFactory
         ));
 
         $phpDocTagNodes[] = new SpacelessPhpDocTagNode('@ORM\GeneratedValue', new DoctrineAnnotationTagValueNode(
-            'Doctrine\ORM\Mapping\GeneratedValue',
+            new IdentifierTypeNode('Doctrine\ORM\Mapping\GeneratedValue'),
             null,
             [
                 'strategy' => '"AUTO"',

--- a/src/NodeFactory/TranslationClassNodeFactory.php
+++ b/src/NodeFactory/TranslationClassNodeFactory.php
@@ -6,6 +6,7 @@ namespace Rector\Doctrine\NodeFactory;
 
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\NodeManipulator\ClassInsertManipulator;
@@ -31,7 +32,7 @@ final class TranslationClassNodeFactory
 
         $spacelessPhpDocTagNode = new \Rector\BetterPhpDocParser\PhpDoc\SpacelessPhpDocTagNode(
             '@ORM\Entity',
-            new DoctrineAnnotationTagValueNode('Doctrine\ORM\Mapping\Entity', null, [])
+            new DoctrineAnnotationTagValueNode(new IdentifierTypeNode('Doctrine\ORM\Mapping\Entity'), null, [])
         );
 
         $phpDocInfo->addPhpDocTagNode($spacelessPhpDocTagNode);

--- a/src/Rector/Class_/ClassAnnotationToNamedArgumentConstructorRector.php
+++ b/src/Rector/Class_/ClassAnnotationToNamedArgumentConstructorRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\Type\ArrayType;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
@@ -110,7 +111,7 @@ CODE_SAMPLE
         }
 
         $doctrineAnnotationTagValueNode = new DoctrineAnnotationTagValueNode(
-            'Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor'
+            new IdentifierTypeNode('Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor')
         );
         $phpDocInfo->addTagValueNode($doctrineAnnotationTagValueNode);
 


### PR DESCRIPTION
Run composer update make `DoctrineAnnotationTagValueNode::__construct()` first parameter require `IdentifierTypeNode` instance instead of string, this patch pass new instance of `IdentifierTypeNode`.