### PR TITLE
add Doctrine ODM 2.3 set

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "symplify/easy-coding-standard": "^9.4",
         "symplify/rule-doc-generator": "^9.4",
         "rector/rector-src": "dev-main",
+        "doctrine/mongodb-odm": "^2.3@dev",
         "doctrine/orm": "^2.9",
         "rector/rector-generator": "^0.2"
     },

--- a/config/sets/doctrine-odm-23.php
+++ b/config/sets/doctrine-odm-23.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(AnnotationToAttributeRector::class)
+        ->call('configure', [[
+            AnnotationToAttributeRector::ANNOTATION_TO_ATTRIBUTE => ValueObjectInliner::inline([
+                new AnnotationToAttribute(MongoDB\AlsoLoad::class),
+                new AnnotationToAttribute(MongoDB\ChangeTrackingPolicy::class),
+                new AnnotationToAttribute(MongoDB\DefaultDiscriminatorValue::class),
+                new AnnotationToAttribute(MongoDB\DiscriminatorField::class),
+                new AnnotationToAttribute(MongoDB\DiscriminatorMap::class),
+                new AnnotationToAttribute(MongoDB\DiscriminatorValue::class),
+                new AnnotationToAttribute(MongoDB\Document::class),
+                new AnnotationToAttribute(MongoDB\EmbeddedDocument::class),
+                new AnnotationToAttribute(MongoDB\EmbedMany::class),
+                new AnnotationToAttribute(MongoDB\EmbedOne::class),
+                new AnnotationToAttribute(MongoDB\Field::class),
+                new AnnotationToAttribute(MongoDB\File::class),
+                new AnnotationToAttribute(MongoDB\File\ChunkSize::class),
+                new AnnotationToAttribute(MongoDB\File\Filename::class),
+                new AnnotationToAttribute(MongoDB\File\Length::class),
+                new AnnotationToAttribute(MongoDB\File\Metadata::class),
+                new AnnotationToAttribute(MongoDB\File\UploadDate::class),
+                new AnnotationToAttribute(MongoDB\HasLifecycleCallbacks::class),
+                new AnnotationToAttribute(MongoDB\Id::class),
+                new AnnotationToAttribute(MongoDB\Index::class),
+                new AnnotationToAttribute(MongoDB\Indexes::class),
+                new AnnotationToAttribute(MongoDB\InheritanceType::class),
+                new AnnotationToAttribute(MongoDB\Lock::class),
+                new AnnotationToAttribute(MongoDB\MappedSuperclass::class),
+                new AnnotationToAttribute(MongoDB\PostLoad::class),
+                new AnnotationToAttribute(MongoDB\PostPersist::class),
+                new AnnotationToAttribute(MongoDB\PostRemove::class),
+                new AnnotationToAttribute(MongoDB\PostUpdate::class),
+                new AnnotationToAttribute(MongoDB\PreFlush::class),
+                new AnnotationToAttribute(MongoDB\PreLoad::class),
+                new AnnotationToAttribute(MongoDB\PrePersist::class),
+                new AnnotationToAttribute(MongoDB\PreRemove::class),
+                new AnnotationToAttribute(MongoDB\PreUpdate::class),
+                new AnnotationToAttribute(MongoDB\QueryResultDocument::class),
+                new AnnotationToAttribute(MongoDB\ReadPreference::class),
+                new AnnotationToAttribute(MongoDB\ReferenceMany::class),
+                new AnnotationToAttribute(MongoDB\ReferenceOne::class),
+                new AnnotationToAttribute(MongoDB\ShardKey::class),
+                new AnnotationToAttribute(MongoDB\UniqueIndex::class),
+                new AnnotationToAttribute(MongoDB\Validation::class),
+                new AnnotationToAttribute(MongoDB\Version::class),
+                new AnnotationToAttribute(MongoDB\View::class),
+            ]),
+        ]]);
+};

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,8 +27,3 @@ parameters:
         # false postiive on class-strng
         - '#getByAnnotationClass\(\) expects class\-string, string given#'
         - '#expects class\-string, string given#'
-
-        # fixed in main
-        - '#Variables "\$entityReferenceExpr" are overridden\. This can lead to unwanted bugs, please pick a different name to avoid it#'
-        - '#Variables "\$hasLoggableAnnotation" are overridden\. This can lead to unwanted bugs, please pick a different name to avoid it#'
-        - '#Variables "\$hasChanged" are overridden\. This can lead to unwanted bugs, please pick a different name to avoid it#'

--- a/src/Set/DoctrineSetList.php
+++ b/src/Set/DoctrineSetList.php
@@ -57,4 +57,9 @@ final class DoctrineSetList implements SetListInterface
      * @var string
      */
     public const DOCTRINE_ORM_29 = __DIR__ . '/../../config/sets/doctrine-orm-29.php';
+
+    /**
+     * @var string
+     */
+    public const DOCTRINE_ODM_23 = __DIR__ . '/../../config/sets/doctrine-odm-23.php';
 }

--- a/tests/Set/DoctrineODM23Set/DoctrineODM23SetTest.php
+++ b/tests/Set/DoctrineODM23Set/DoctrineODM23SetTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DoctrineODM23SetTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_set.php';
+    }
+}

--- a/tests/Set/DoctrineODM23Set/Fixture/change_tracking_policy.php.inc
+++ b/tests/Set/DoctrineODM23Set/Fixture/change_tracking_policy.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\Document
+ * @MongoDB\ChangeTrackingPolicy("DEFERRED_IMPLICIT")
+ */
+class User
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+#[\Doctrine\ODM\MongoDB\Mapping\Annotations\Document]
+#[\Doctrine\ODM\MongoDB\Mapping\Annotations\ChangeTrackingPolicy(value: 'DEFERRED_IMPLICIT')]
+class User
+{
+}
+
+?>

--- a/tests/Set/DoctrineODM23Set/Fixture/embeddable_embedded.php.inc
+++ b/tests/Set/DoctrineODM23Set/Fixture/embeddable_embedded.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\EmbeddedDocument
+ */
+class Address
+{
+}
+
+class User
+{
+    /**
+     * @MongoDB\EmbedOne(targetDocument="Address")
+     */
+    private $address;
+
+    /**
+     * @MongoDB\EmbedMany(targetDocument="Address")
+     */
+    private $addresses;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+#[\Doctrine\ODM\MongoDB\Mapping\Annotations\EmbeddedDocument]
+class Address
+{
+}
+
+class User
+{
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\EmbedOne(targetDocument: 'Address')]
+    private $address;
+
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\EmbedMany(targetDocument: 'Address')]
+    private $addresses;
+}
+
+?>

--- a/tests/Set/DoctrineODM23Set/Fixture/fixture.php.inc
+++ b/tests/Set/DoctrineODM23Set/Fixture/fixture.php.inc
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * News
+ *
+ * @MongoDB\Document(collection="news", repositoryClass="DoctrineFixtureDemo\Repository\NewsRepository")
+ */
+class News
+{
+    /**
+     * @var string
+     *
+     * @MongoDB\Id
+     */
+    private $id;
+    /**
+     * @var string
+     *
+     * @MongoDB\Field(name="title", type="string", nullable=false)
+     */
+    private $title;
+    /**
+     * @var string
+     *
+     * @MongoDB\Field(name="content", type="string", nullable=false)
+     */
+    private $content;
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * News
+ */
+#[\Doctrine\ODM\MongoDB\Mapping\Annotations\Document(collection: 'news', repositoryClass: 'DoctrineFixtureDemo\Repository\NewsRepository')]
+class News
+{
+    /**
+     * @var string
+     */
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\Id]
+    private $id;
+    /**
+     * @var string
+     */
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\Field(name: 'title', type: 'string', nullable: false)]
+    private $title;
+    /**
+     * @var string
+     */
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\Field(name: 'content', type: 'string', nullable: false)]
+    private $content;
+}
+
+?>

--- a/tests/Set/DoctrineODM23Set/Fixture/has_lifecycle_calbacks.php.inc
+++ b/tests/Set/DoctrineODM23Set/Fixture/has_lifecycle_calbacks.php.inc
@@ -1,0 +1,99 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\Document
+ * @MongoDB\HasLifecycleCallbacks
+ */
+class User
+{
+    /**
+     * @MongoDB\PostLoad
+     */
+    public function methodPostLoad()
+    {
+    }
+    /**
+     * @MongoDB\PrePersist
+     */
+    public function methodPrePersist()
+    {
+    }
+    /**
+     * @MongoDB\PostPersist
+     */
+    public function methodPostPersist()
+    {
+    }
+    /**
+     * @MongoDB\PreRemove
+     */
+    public function methodPreRemove()
+    {
+    }
+    /**
+     * @MongoDB\PostRemove
+     */
+    public function methodPostRemove()
+    {
+    }
+    /**
+     * @MongoDB\PreUpdate
+     */
+    public function methodPreUpdate()
+    {
+    }
+    /**
+     * @MongoDB\PostUpdate
+     */
+    public function methodPostUpdate()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+#[\Doctrine\ODM\MongoDB\Mapping\Annotations\Document]
+#[\Doctrine\ODM\MongoDB\Mapping\Annotations\HasLifecycleCallbacks]
+class User
+{
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\PostLoad]
+    public function methodPostLoad()
+    {
+    }
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\PrePersist]
+    public function methodPrePersist()
+    {
+    }
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\PostPersist]
+    public function methodPostPersist()
+    {
+    }
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\PreRemove]
+    public function methodPreRemove()
+    {
+    }
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\PostRemove]
+    public function methodPostRemove()
+    {
+    }
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\PreUpdate]
+    public function methodPreUpdate()
+    {
+    }
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\PostUpdate]
+    public function methodPostUpdate()
+    {
+    }
+}
+
+?>

--- a/tests/Set/DoctrineODM23Set/Fixture/index.php.inc
+++ b/tests/Set/DoctrineODM23Set/Fixture/index.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\Document()
+ * @MongoDB\Index(name="search_idx", keys={"name", "c"})
+ */
+class ECommerceProduct
+{
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+#[\Doctrine\ODM\MongoDB\Mapping\Annotations\Document]
+#[\Doctrine\ODM\MongoDB\Mapping\Annotations\Index(name: 'search_idx', keys: ['name', 'c'])]
+class ECommerceProduct
+{
+}
+
+?>

--- a/tests/Set/DoctrineODM23Set/Fixture/mapped_superclass.php.inc
+++ b/tests/Set/DoctrineODM23Set/Fixture/mapped_superclass.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\MappedSuperclass
+ */
+abstract class BaseDocument
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+#[\Doctrine\ODM\MongoDB\Mapping\Annotations\MappedSuperclass]
+abstract class BaseDocument
+{
+}
+
+?>

--- a/tests/Set/DoctrineODM23Set/Fixture/reference_one.php.inc
+++ b/tests/Set/DoctrineODM23Set/Fixture/reference_one.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+/**
+ * @MongoDB\Document
+ */
+class Product
+{
+    /**
+     * @MongoDB\ReferenceMany(targetDocument=Feature::class, mappedBy="product")
+     */
+    private $features;
+}
+
+class Feature
+{
+    /**
+     * @MongoDB\ReferenceOne(targetDocument=Product::class, storeAs="id", name="productId")
+     */
+    private $product;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Set\DoctrineODM23Set\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+
+#[\Doctrine\ODM\MongoDB\Mapping\Annotations\Document]
+class Product
+{
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\ReferenceMany(targetDocument: Feature::class, mappedBy: 'product')]
+    private $features;
+}
+
+class Feature
+{
+    #[\Doctrine\ODM\MongoDB\Mapping\Annotations\ReferenceOne(targetDocument: Product::class, storeAs: 'id', name: 'productId')]
+    private $product;
+}
+
+?>

--- a/tests/Set/DoctrineODM23Set/config/configured_set.php
+++ b/tests/Set/DoctrineODM23Set/config/configured_set.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Doctrine\Set\DoctrineSetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/../../../../config/config.php');
+    $containerConfigurator->import(DoctrineSetList::DOCTRINE_ODM_23);
+};

--- a/tests/Set/DoctrineORM29Set/Fixture/embeddable_embedded.php.inc
+++ b/tests/Set/DoctrineORM29Set/Fixture/embeddable_embedded.php.inc
@@ -15,7 +15,7 @@ class Address
 class User
 {
     /**
-     * @Embedded(class: "Address")
+     * @Embedded(class="Address")
      */
     private $address;
 }
@@ -36,7 +36,7 @@ class Address
 
 class User
 {
-    #[\Doctrine\ORM\Mapping\Embedded(class: 'class')]
+    #[\Doctrine\ORM\Mapping\Embedded(class: 'Address')]
     private $address;
 }
 


### PR DESCRIPTION
This feature introduces a set that converts Doctrine ODM annotations into PHP 8 attributes which will be supported in upcoming Doctrine ODM 2.3: https://github.com/doctrine/mongodb-odm/blob/2.3.x/UPGRADE-2.3.md