### PR TITLE
ImproveDoctrineCollectionDocTypeInEntityRector: tests for adder-methods

### DIFF
--- a/tests/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/adder_param.php.inc
+++ b/tests/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/adder_param.php.inc
@@ -32,7 +32,7 @@ final class AdderParam
 }
 
 ?>
-    -----
+-----
 <?php
 
 namespace Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Fixture;

--- a/tests/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/adder_param.php.inc
+++ b/tests/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/adder_param.php.inc
@@ -1,0 +1,69 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Fixture;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training;
+
+/**
+ * @ORM\Entity
+ */
+final class AdderParam
+{
+    /**
+     * @ORM\OneToMany(targetEntity=Training::class, mappedBy="trainer")
+     */
+    private $trainings = [];
+
+
+    /**
+     * @param \Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training $training
+     * @return $this
+     */
+    public function addTraining(\Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training $training): self
+    {
+        if (!$this->trainings->contains($training)) {
+            $this->trainings[] = $training;
+        }
+
+        return $this;
+    }
+}
+
+?>
+    -----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Fixture;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training;
+
+/**
+ * @ORM\Entity
+ */
+final class AdderParam
+{
+    /**
+     * @ORM\OneToMany(targetEntity=Training::class, mappedBy="trainer")
+     * @var \Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training[]|\Doctrine\Common\Collections\Collection<int, \Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training>
+     */
+    private $trainings = [];
+
+    /**
+     * @param \Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training $training
+     * @return $this
+     */
+    public function addTraining(\Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training $training): self
+    {
+        if (!$this->trainings->contains($training)) {
+            $this->trainings[] = $training;
+        }
+
+        return $this;
+    }
+}
+
+?>

--- a/tests/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/adder_param_with_typehint_only.php.inc
+++ b/tests/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/adder_param_with_typehint_only.php.inc
@@ -9,7 +9,7 @@ use Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEnti
 /**
  * @ORM\Entity
  */
-final class ParamWithTypehintOnly
+final class AdderParamWithTypehintOnly
 {
     /**
      * @ORM\OneToMany(targetEntity=Training::class, mappedBy="trainer")
@@ -40,7 +40,7 @@ use Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEnti
 /**
  * @ORM\Entity
  */
-final class ParamWithTypehintOnly
+final class AdderParamWithTypehintOnly
 {
     /**
      * @ORM\OneToMany(targetEntity=Training::class, mappedBy="trainer")

--- a/tests/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/adder_param_with_typehint_only.php.inc
+++ b/tests/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/adder_param_with_typehint_only.php.inc
@@ -28,7 +28,7 @@ final class AdderParamWithTypehintOnly
 }
 
 ?>
-    -----
+-----
 <?php
 
 namespace Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Fixture;

--- a/tests/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/param_with_typehint_only.php.inc
+++ b/tests/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/param_with_typehint_only.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Fixture;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training;
+
+/**
+ * @ORM\Entity
+ */
+final class ParamWithTypehintOnly
+{
+    /**
+     * @ORM\OneToMany(targetEntity=Training::class, mappedBy="trainer")
+     */
+    private $trainings = [];
+
+
+    public function addTraining(\Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training $training): self
+    {
+        if (!$this->trainings->contains($training)) {
+            $this->trainings[] = $training;
+        }
+
+        return $this;
+    }
+}
+
+?>
+    -----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Fixture;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training;
+
+/**
+ * @ORM\Entity
+ */
+final class ParamWithTypehintOnly
+{
+    /**
+     * @ORM\OneToMany(targetEntity=Training::class, mappedBy="trainer")
+     * @var \Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training[]|\Doctrine\Common\Collections\Collection<int, \Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training>
+     */
+    private $trainings = [];
+
+    public function addTraining(\Rector\Doctrine\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training $training): self
+    {
+        if (!$this->trainings->contains($training)) {
+            $this->trainings[] = $training;
+        }
+
+        return $this;
+    }
+}
+
+?>


### PR DESCRIPTION
As mentioned in rectorphp/rector#6802 the current rector `ImproveDoctrineCollectionDocTypeInEntityRector` tries to refactor adder-methods which add a property into a Collection and do not set the Collection themselves.

example: https://getrector.org/demo/1ec42f47-50b9-67ae-976d-a39026359381
