### PR TITLE
Dont Touch Unrelated Code by TypedPropertyFromToManyRelationTypeRector unit test

### DIFF
--- a/tests/Rector/Property/TypedPropertyFromToManyRelationTypeRector/Fixture/dont_touch_unrelated_code.php.inc
+++ b/tests/Rector/Property/TypedPropertyFromToManyRelationTypeRector/Fixture/dont_touch_unrelated_code.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\TypedPropertyFromToManyRelationTypeRector\Fixture;
+
+class DontTouchUnrelatedCode
+{
+    public $training;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\TypedPropertyFromToManyRelationTypeRector\Fixture;
+
+class DontTouchUnrelatedCode
+{
+    public $training;
+}
+
+?>


### PR DESCRIPTION
Herewith a failing unit test.

The `TypedPropertyFromToManyRelationTypeRector` should not make any changes to this class, but it does. 

<img width="1604" alt="Screenshot 2022-01-18 at 08 14 19" src="https://user-images.githubusercontent.com/400092/149897183-9a0d69a1-1b70-40a2-8831-6dc01c0896f1.png">

