### PR TITLE
skip refactorToBoolType() if the default is a Class-Constant

### DIFF
--- a/src/Rector/Property/CorrectDefaultTypesOnEntityPropertyRector.php
+++ b/src/Rector/Property/CorrectDefaultTypesOnEntityPropertyRector.php
@@ -6,6 +6,7 @@ namespace Rector\Doctrine\Rector\Property;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
@@ -116,7 +117,7 @@ CODE_SAMPLE
             ) ? $this->nodeFactory->createTrue() : $this->nodeFactory->createFalse();
             return $property;
         }
-        if ($defaultExpr instanceof ConstFetch) {
+        if ($defaultExpr instanceof ConstFetch || $defaultExpr instanceof ClassConstFetch) {
             // already ok
             return null;
         }

--- a/tests/Rector/Property/CorrectDefaultTypesOnEntityPropertyRector/Fixture/skip_class_const_initialized_bool_property.php.inc
+++ b/tests/Rector/Property/CorrectDefaultTypesOnEntityPropertyRector/Fixture/skip_class_const_initialized_bool_property.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\CorrectDefaultTypesOnEntityPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+define("DEFAULT_CONST") = true;
+
+final class SkipConstInitializedBoolProperty
+{
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private ?bool $isActive = DEFAULT_CONST;
+}

--- a/tests/Rector/Property/CorrectDefaultTypesOnEntityPropertyRector/Fixture/skip_const_initialized_bool_property.php.inc
+++ b/tests/Rector/Property/CorrectDefaultTypesOnEntityPropertyRector/Fixture/skip_const_initialized_bool_property.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\CorrectDefaultTypesOnEntityPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+final class SkipConstInitializedBoolProperty
+{
+
+    public const DEFAULT_CONST = true;
+
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private ?bool $isActive = self::DEFAULT_CONST;
+}


### PR DESCRIPTION
not only for global Constants

fixes #84 