### PR TITLE
Add failing test to demonstrate issue with InitializeDefaultEntityCollectionRector

### DIFF
--- a/tests/Rector/Class_/InitializeDefaultEntityCollectionRector/Fixture/skip_added_values.php.inc
+++ b/tests/Rector/Class_/InitializeDefaultEntityCollectionRector/Fixture/skip_added_values.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Class_\InitializeDefaultEntityCollectionRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @ORM\Entity
+ */
+class SkipAddedValues
+{
+    /**
+     * @ORM\OneToMany(targetEntity="MarketingEvent")
+     */
+    private $marketingEvents = [];
+
+    public function __construct(array $marketingEvents)
+    {
+        $this->marketingEvents = new ArrayCollection([$marketingEvents]);
+        $value = 5;
+    }
+}


### PR DESCRIPTION
Rector seems to add additional initialization call when one with arguments already exists.