### PR TITLE
[Doctrine] Skip pointed to constant value on CorrectDefaultTypesOnEntityPropertyRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -38,5 +38,3 @@ parameters:
             paths:
                 - tests/Rector/Property/TypedPropertyFromColumnTypeRector/config/non_typed_properties.php
                 - tests/Set/DoctrineORM29Set/config/configured_set.php
-
-        - '#New objects with "\$.*" name are overridden\. This can lead to unwanted bugs, please pick a different name to avoid it#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -29,11 +29,6 @@ parameters:
         # rector co-variant
         - '#Parameter \#1 \$node \(PhpParser\\Node\\(.*?) of method Rector\\(.*?)\(\) should be contravariant with parameter \$node \(PhpParser\\Node\) of method Rector\\Core\\Contract\\Rector\\PhpRectorInterface\:\:refactor\(\)#'
 
-        -
-            message: '#Array with keys is not allowed\. Use value object to pass data instead#'
-            paths:
-                - src/NodeManipulator/ColumnPropertyTypeResolver.php
-
         # false positive
         - '#Parameter \#1 \$tag of method Rector\\BetterPhpDocParser\\PhpDocParser\\ClassAnnotationMatcher\:\:resolveTagFullyQualifiedName\(\) expects string, string\|null given#'
         - '#Parameter \#2 \$filter of method Rector\\Core\\PhpParser\\Node\\BetterNodeFinder\:\:findFirst\(\) expects callable\(PhpParser\\Node\)\: bool, Closure\(PhpParser\\Node\)\: PhpParser\\Node\\Expr\\Assign\|null given#'
@@ -44,5 +39,4 @@ parameters:
                 - tests/Rector/Property/TypedPropertyFromColumnTypeRector/config/non_typed_properties.php
                 - tests/Set/DoctrineORM29Set/config/configured_set.php
 
-        # temporary for tests
-        - '#The path "/\.\./preload\.php" was not found#'
+        - '#New objects with "\$.*" name are overridden\. This can lead to unwanted bugs, please pick a different name to avoid it#'

--- a/src/NodeFactory/ParamFactory.php
+++ b/src/NodeFactory/ParamFactory.php
@@ -63,13 +63,15 @@ final class ParamFactory
         // the param is optional - make it nullable
         if (in_array($propertyName, $optionalParamNames, true)) {
             if (! $paramTypeNode instanceof ComplexType && $paramTypeNode !== null) {
-                $paramTypeNode = new NullableType($paramTypeNode);
+                $param->type = new NullableType($paramTypeNode);
             }
 
             $param->default = $this->nodeFactory->createNull();
         }
 
-        $param->type = $paramTypeNode;
+        if ($param->type === null) {
+            $param->type = $paramTypeNode;
+        }
 
         return $param;
     }

--- a/src/Rector/Class_/TranslationBehaviorRector.php
+++ b/src/Rector/Class_/TranslationBehaviorRector.php
@@ -182,12 +182,12 @@ CODE_SAMPLE
         $classShortName = $class->name . 'Translation';
         $filePath = dirname($smartFileInfo->getRealPath()) . DIRECTORY_SEPARATOR . $classShortName . '.php';
 
-        $namespace = $class->getAttribute(AttributeKey::PARENT_NODE);
-        if (! $namespace instanceof Namespace_) {
+        $parentNode = $class->getAttribute(AttributeKey::PARENT_NODE);
+        if (! $parentNode instanceof Namespace_) {
             throw new ShouldNotHappenException();
         }
 
-        $namespace = new Namespace_($namespace->name);
+        $namespace = new Namespace_($parentNode->name);
         $class = $this->translationClassNodeFactory->create($classShortName);
 
         foreach ($propertyNamesAndPhpDocInfos->all() as $propertyNameAndPhpDocInfo) {

--- a/src/Rector/Property/CorrectDefaultTypesOnEntityPropertyRector.php
+++ b/src/Rector/Property/CorrectDefaultTypesOnEntityPropertyRector.php
@@ -147,6 +147,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($defaultExpr instanceof ClassConstFetch || $defaultExpr instanceof ConstFetch) {
+            return null;
+        }
+
         throw new NotImplementedYetException();
     }
 }

--- a/tests/Rector/Property/CorrectDefaultTypesOnEntityPropertyRector/Fixture/skip_pointed_to_constant_value.php.inc
+++ b/tests/Rector/Property/CorrectDefaultTypesOnEntityPropertyRector/Fixture/skip_pointed_to_constant_value.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\CorrectDefaultTypesOnEntityPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class PointedToConstantValue
+{
+    public const ONE = 1;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $stav = self::ONE;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $stav2 = SOME_CONSTANT_VALUE;
+}


### PR DESCRIPTION
Given the following code:

```php
/**
 * @ORM\Entity()
 */
class PointedToConstantValue
{
    public const ONE = 1;

    /**
     * @ORM\Column(type="integer")
     */
    private $stav = self::ONE;

    /**
     * @ORM\Column(type="integer")
     */
    private $stav2 = SOME_CONSTANT_VALUE;
}
```

It currently make crash:

```bash
There was 1 error:

1) Rector\Doctrine\Tests\Rector\Property\CorrectDefaultTypesOnEntityPropertyRector\CorrectDefaultTypesOnEntityPropertyRectorTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Rector\Core\Exception\NotImplementedYetException: 
```

This PR fix it. 
Fixes https://github.com/rectorphp/rector/issues/7227