### PR TITLE
Add TypedPropertyFromDoctrineCollectionRector

### DIFF
--- a/config/sets/doctrine-code-quality.php
+++ b/config/sets/doctrine-code-quality.php
@@ -14,6 +14,7 @@ use Rector\Doctrine\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRect
 use Rector\Doctrine\Rector\Property\MakeEntityDateTimePropertyDateTimeInterfaceRector;
 use Rector\Doctrine\Rector\Property\RemoveRedundantDefaultPropertyAnnotationValuesRector;
 use Rector\Doctrine\Rector\Property\TypedPropertyFromColumnTypeRector;
+use Rector\Doctrine\Rector\Property\TypedPropertyFromDoctrineCollectionRector;
 use Rector\Doctrine\Rector\Property\TypedPropertyFromToManyRelationTypeRector;
 use Rector\Doctrine\Rector\Property\TypedPropertyFromToOneRelationTypeRector;
 use Rector\Privatization\Rector\MethodCall\ReplaceStringWithClassConstantRector;
@@ -39,6 +40,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(TypedPropertyFromColumnTypeRector::class);
     $rectorConfig->rule(TypedPropertyFromToOneRelationTypeRector::class);
     $rectorConfig->rule(TypedPropertyFromToManyRelationTypeRector::class);
+    $rectorConfig->rule(TypedPropertyFromDoctrineCollectionRector::class);
 
     $rectorConfig->ruleWithConfiguration(AttributeKeyToClassConstFetchRector::class, [
         new AttributeKeyToClassConstFetch('Doctrine\ORM\Mapping\Column', 'type', 'Doctrine\DBAL\Types\Types', [

--- a/src/Rector/Property/TypedPropertyFromDoctrineCollectionRector.php
+++ b/src/Rector/Property/TypedPropertyFromDoctrineCollectionRector.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Rector\Property;
+
+use PhpParser\Node;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Doctrine\TypeAnalyzer\DoctrineCollectionTypeAnalyzer;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Doctrine\Tests\Rector\Property\TypedPropertyFromDoctrineCollectionRector\TypedPropertyFromDoctrineCollectionRectorTest
+ */
+final class TypedPropertyFromDoctrineCollectionRector extends AbstractRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly DoctrineCollectionTypeAnalyzer $doctrineCollectionTypeAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Add typed property based on Doctrine collection', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use Doctrine\ORM\Mapping as ORM;
+use App\Entity\TrainingTerm;
+
+/**
+ * @ORM\Entity
+ */
+class DoctrineCollection
+{
+    /**
+     * @ORM\OneToMany(targetEntity="App\Entity\TrainingTerm", mappedBy="training")
+     * @var TrainingTerm[]|Collection
+     */
+    private $trainingTerms;
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+use Doctrine\ORM\Mapping as ORM;
+use App\Entity\TrainingTerm;
+
+/**
+ * @ORM\Entity
+ */
+class DoctrineCollection
+{
+    /**
+     * @ORM\OneToMany(targetEntity="App\Entity\TrainingTerm", mappedBy="training")
+     * @var TrainingTerm[]|Collection
+     */
+    private \Doctrine\Common\Collections\Collection $trainingTerms;
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Property::class];
+    }
+
+    /**
+     * @param Property $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->type !== null) {
+            return null;
+        }
+
+        $propertyPhpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (! $propertyPhpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+
+        $varTagValueNode = $propertyPhpDocInfo->getVarTagValueNode();
+        if (! $varTagValueNode instanceof VarTagValueNode) {
+            return null;
+        }
+
+        $varTagType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($varTagValueNode->type, $node);
+
+        if (! $this->doctrineCollectionTypeAnalyzer->detect($varTagType)) {
+            return null;
+        }
+
+        $node->type = new FullyQualified('Doctrine\Common\Collections\Collection');
+
+        return $node;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersion::PHP_74;
+    }
+}

--- a/src/TypeAnalyzer/DoctrineCollectionTypeAnalyzer.php
+++ b/src/TypeAnalyzer/DoctrineCollectionTypeAnalyzer.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\TypeAnalyzer;
+
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeWithClassName;
+use PHPStan\Type\UnionType;
+use Rector\StaticTypeMapper\ValueObject\Type\ShortenedObjectType;
+
+/**
+ * @todo replaces core one
+ * @see \Rector\PHPStanStaticTypeMapper\DoctrineTypeAnalyzer
+ */
+final class DoctrineCollectionTypeAnalyzer
+{
+    public function detect(Type $type): bool
+    {
+        if (! $type instanceof UnionType) {
+            return false;
+        }
+
+        $arrayType = null;
+        $hasDoctrineCollectionType = false;
+        foreach ($type->getTypes() as $unionedType) {
+            if ($this->isCollectionObjectType($unionedType)) {
+                $hasDoctrineCollectionType = true;
+            }
+
+            if ($unionedType instanceof ArrayType) {
+                $arrayType = $unionedType;
+            }
+        }
+
+        if (! $hasDoctrineCollectionType) {
+            return false;
+        }
+
+        return $arrayType !== null;
+    }
+
+    private function isCollectionObjectType(Type $type): bool
+    {
+        if (! $type instanceof TypeWithClassName) {
+            return false;
+        }
+
+        if ($type instanceof ShortenedObjectType) {
+            $className = $type->getFullyQualifiedName();
+        } else {
+            $className = $type->getClassName();
+        }
+
+        return $className === 'Doctrine\Common\Collections\Collection';
+    }
+}

--- a/tests/Rector/Property/TypedPropertyFromDoctrineCollectionRector/Fixture/some_class.php.inc
+++ b/tests/Rector/Property/TypedPropertyFromDoctrineCollectionRector/Fixture/some_class.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\TypedPropertyFromDoctrineCollectionRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\Collection;
+use Rector\Doctrine\Tests\Rector\Property\TypedPropertyFromDoctrineCollectionRector\Source\Entity\TrainingTerm;
+
+/**
+ * @ORM\Entity
+ */
+class DoctrineCollection
+{
+    /**
+     * @ORM\OneToMany(targetEntity="App\Entity\TrainingTerm", mappedBy="training")
+     * @var TrainingTerm[]|Collection
+     */
+    private $trainingTerms;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\TypedPropertyFromDoctrineCollectionRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\Collection;
+use Rector\Doctrine\Tests\Rector\Property\TypedPropertyFromDoctrineCollectionRector\Source\Entity\TrainingTerm;
+
+/**
+ * @ORM\Entity
+ */
+class DoctrineCollection
+{
+    /**
+     * @ORM\OneToMany(targetEntity="App\Entity\TrainingTerm", mappedBy="training")
+     * @var TrainingTerm[]|Collection
+     */
+    private \Doctrine\Common\Collections\Collection $trainingTerms;
+}
+
+?>

--- a/tests/Rector/Property/TypedPropertyFromDoctrineCollectionRector/Source/Entity/TrainingTerm.php
+++ b/tests/Rector/Property/TypedPropertyFromDoctrineCollectionRector/Source/Entity/TrainingTerm.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Rector\Property\TypedPropertyFromDoctrineCollectionRector\Source\Entity;
+
+final class TrainingTerm
+{
+
+}

--- a/tests/Rector/Property/TypedPropertyFromDoctrineCollectionRector/TypedPropertyFromDoctrineCollectionRectorTest.php
+++ b/tests/Rector/Property/TypedPropertyFromDoctrineCollectionRector/TypedPropertyFromDoctrineCollectionRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Rector\Property\TypedPropertyFromDoctrineCollectionRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class TypedPropertyFromDoctrineCollectionRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/Property/TypedPropertyFromDoctrineCollectionRector/config/configured_rule.php
+++ b/tests/Rector/Property/TypedPropertyFromDoctrineCollectionRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\Rector\Property\TypedPropertyFromDoctrineCollectionRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(TypedPropertyFromDoctrineCollectionRector::class);
+};


### PR DESCRIPTION
This separated doctrine collection types from `TypedPropertyRector` which is now doing too much.
See the feature in the core: https://github.com/rectorphp/rector-src/commit/aa9588f261324674cda0554c4b09d13a299b2dcd

The goal is to split rule to separated responsibility ones, with idempotent design and separated responsibilites.