### PR TITLE
Resolve Doctrine Target Entities to known Classes only

### DIFF
--- a/src/Rector/Property/DoctrineTargetEntityStringToClassConstantRector.php
+++ b/src/Rector/Property/DoctrineTargetEntityStringToClassConstantRector.php
@@ -125,7 +125,7 @@ CODE_SAMPLE
 
             /** @var string $value - Should always be string at this point */
             $value = $this->valueResolver->getValue($arg->value);
-            $fullyQualified = $this->classAnnotationMatcher->resolveTagFullyQualifiedName($value, $property);
+            $fullyQualified = $this->classAnnotationMatcher->resolveTagToKnownFullyQualifiedName($value, $property);
 
             if ($fullyQualified === $value) {
                 continue;


### PR DESCRIPTION
Hi there!

This is a follow up on my work at https://github.com/rectorphp/rector-src/pull/2319 . It changes DoctrineTargetEntityStringToClassConstantRector to resolve known classes only.