### PR TITLE
Fix resolving Doctrine Target Entities to known Classes only

### DIFF
--- a/src/Rector/Property/DoctrineTargetEntityStringToClassConstantRector.php
+++ b/src/Rector/Property/DoctrineTargetEntityStringToClassConstantRector.php
@@ -169,7 +169,14 @@ CODE_SAMPLE
         }
 
         // resolve to FQN
-        $tagFullyQualifiedName = $this->classAnnotationMatcher->resolveTagFullyQualifiedName($targetEntity, $property);
+        $tagFullyQualifiedName = $this->classAnnotationMatcher->resolveTagToKnownFullyQualifiedName(
+            $targetEntity,
+            $property
+        );
+
+        if ($tagFullyQualifiedName === null) {
+            return null;
+        }
 
         if ($tagFullyQualifiedName === $targetEntity) {
             return null;


### PR DESCRIPTION
Hi!

I forgot these changes in my last PR (#111). Apologies for that.
In order to resolve only to known classes, we need to replace all calls to `$classAnnotationMatcher->resolveTagFullyQualifiedName()` to `$classAnnotationMatcher->resolveTagToKnownFullyQualifiedName()`.