### PR TITLE
Fix resolving doctrine target entities with omitted leading backslash

### DIFF
--- a/src/PhpDocParser/DoctrineClassAnnotationMatcher.php
+++ b/src/PhpDocParser/DoctrineClassAnnotationMatcher.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\PhpDocParser;
+
+use PhpParser\Node;
+use Rector\BetterPhpDocParser\PhpDocParser\ClassAnnotationMatcher;
+
+class DoctrineClassAnnotationMatcher
+{
+    public function __construct(private readonly ClassAnnotationMatcher $classAnnotationMatcher)
+    {
+    }
+
+    public function resolveExpectingDoctrineFQCN(string $value, Node $property): ?string
+    {
+        $fullyQualified = $this->classAnnotationMatcher->resolveTagToKnownFullyQualifiedName($value, $property);
+
+        if ($fullyQualified === null) {
+            // Doctrine FQCNs are strange: In their examples
+            // they omit the leading slash. This leads to
+            // ClassAnnotationMatcher searching in the wrong
+            // namespace. Therefor we try to add the leading
+            // slash manually here.
+            $fullyQualified = $this->classAnnotationMatcher->resolveTagToKnownFullyQualifiedName(
+                '\\' . $value,
+                $property
+            );
+        }
+
+        return $fullyQualified;
+    }
+}

--- a/src/PhpDocParser/DoctrineClassAnnotationMatcher.php
+++ b/src/PhpDocParser/DoctrineClassAnnotationMatcher.php
@@ -13,9 +13,9 @@ class DoctrineClassAnnotationMatcher
     {
     }
 
-    public function resolveExpectingDoctrineFQCN(string $value, Node $property): ?string
+    public function resolveExpectingDoctrineFQCN(string $value, Node $node): ?string
     {
-        $fullyQualified = $this->classAnnotationMatcher->resolveTagToKnownFullyQualifiedName($value, $property);
+        $fullyQualified = $this->classAnnotationMatcher->resolveTagToKnownFullyQualifiedName($value, $node);
 
         if ($fullyQualified === null) {
             // Doctrine FQCNs are strange: In their examples
@@ -25,7 +25,7 @@ class DoctrineClassAnnotationMatcher
             // slash manually here.
             $fullyQualified = $this->classAnnotationMatcher->resolveTagToKnownFullyQualifiedName(
                 '\\' . $value,
-                $property
+                $node
             );
         }
 

--- a/src/Rector/Property/DoctrineTargetEntityStringToClassConstantRector.php
+++ b/src/Rector/Property/DoctrineTargetEntityStringToClassConstantRector.php
@@ -94,27 +94,28 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $hasChanged = false;
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
         if ($phpDocInfo !== null) {
             $property = $this->changeTypeInAnnotationTypes($node, $phpDocInfo);
-            $hasChanged = $property !== null || $phpDocInfo->hasChanged();
+            $annotationDetected = $property !== null || $phpDocInfo->hasChanged();
+
+            if ($annotationDetected) {
+                return $property;
+            }
         }
 
-        return $this->changeTypeInAttributeTypes($node, $hasChanged);
+        return $this->changeTypeInAttributeTypes($node);
     }
 
-    private function changeTypeInAttributeTypes(Property $property, bool $hasChanged): ?Property
+    private function changeTypeInAttributeTypes(Property $property): ?Property
     {
         $attribute = $this->attributeFinder->findAttributeByClasses($property, $this->getAttributeClasses());
 
         if (! $attribute instanceof Attribute) {
-            return $hasChanged ? $property : null;
+            return null;
         }
 
-        $property = $this->changeTypeInAttribute($attribute, $property);
-
-        return $hasChanged ? $property : null;
+        return $this->changeTypeInAttribute($attribute, $property);
     }
 
     private function changeTypeInAttribute(Attribute $attribute, Property $property): ?Property

--- a/src/Rector/Property/DoctrineTargetEntityStringToClassConstantRector.php
+++ b/src/Rector/Property/DoctrineTargetEntityStringToClassConstantRector.php
@@ -42,7 +42,7 @@ final class DoctrineTargetEntityStringToClassConstantRector extends AbstractRect
     ];
 
     public function __construct(
-        private readonly DoctrineClassAnnotationMatcher $classAnnotationMatcher,
+        private readonly DoctrineClassAnnotationMatcher $doctrineClassAnnotationMatcher,
         private readonly AttributeFinder $attributeFinder
     ) {
     }
@@ -133,7 +133,7 @@ CODE_SAMPLE
 
             /** @var string $value - Should always be string at this point */
             $value = $this->valueResolver->getValue($arg->value);
-            $fullyQualified = $this->classAnnotationMatcher->resolveExpectingDoctrineFQCN($value, $property);
+            $fullyQualified = $this->doctrineClassAnnotationMatcher->resolveExpectingDoctrineFQCN($value, $property);
 
             if ($fullyQualified === $value) {
                 continue;
@@ -181,7 +181,7 @@ CODE_SAMPLE
         }
 
         // resolve to FQN
-        $tagFullyQualifiedName = $this->classAnnotationMatcher->resolveExpectingDoctrineFQCN(
+        $tagFullyQualifiedName = $this->doctrineClassAnnotationMatcher->resolveExpectingDoctrineFQCN(
             $targetEntity,
             $property
         );

--- a/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Annotation/doctrine_string_target_entity_to_class.php.inc
+++ b/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Annotation/doctrine_string_target_entity_to_class.php.inc
@@ -43,6 +43,11 @@ final class MyEntity
      */
     private readonly ?Collection $items6;
 
+    /**
+     * @ORM\ManyToOne(targetEntity="Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass")
+     */
+    private readonly ?Collection $items7;
+
     public function addItem(AnotherClass $myOtherEntity): void
     {
         $this->items->add($myOtherEntity);
@@ -95,6 +100,11 @@ final class MyEntity
      * @ORM\ManyToOne(targetEntity="App:AnotherClass")
      */
     private readonly ?Collection $items6;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=\Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass::class)
+     */
+    private readonly ?Collection $items7;
 
     public function addItem(AnotherClass $myOtherEntity): void
     {

--- a/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Annotation/doctrine_string_target_entity_to_class.php.inc
+++ b/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Annotation/doctrine_string_target_entity_to_class.php.inc
@@ -33,21 +33,6 @@ final class MyEntity
      */
     private readonly ?Collection $items4;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="UnresolvableClass")
-     */
-    private readonly ?Collection $items5;
-
-    /**
-     * @ORM\ManyToOne(targetEntity="App:AnotherClass")
-     */
-    private readonly ?Collection $items6;
-
-    /**
-     * @ORM\ManyToOne(targetEntity="Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass")
-     */
-    private readonly ?Collection $items7;
-
     public function addItem(AnotherClass $myOtherEntity): void
     {
         $this->items->add($myOtherEntity);
@@ -90,21 +75,6 @@ final class MyEntity
      * @ORM\OneToOne(mappedBy="class", targetEntity=\Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass::class)
      */
     private readonly ?Collection $items4;
-
-    /**
-     * @ORM\ManyToOne(targetEntity="UnresolvableClass")
-     */
-    private readonly ?Collection $items5;
-
-    /**
-     * @ORM\ManyToOne(targetEntity="App:AnotherClass")
-     */
-    private readonly ?Collection $items6;
-
-    /**
-     * @ORM\ManyToOne(targetEntity=\Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass::class)
-     */
-    private readonly ?Collection $items7;
 
     public function addItem(AnotherClass $myOtherEntity): void
     {

--- a/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Annotation/resolve_string_classes_with_entity_namespace.php.inc
+++ b/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Annotation/resolve_string_classes_with_entity_namespace.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Fixture\Annotation;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass;
+
+/**
+ * @see https://github.com/doctrine/orm/issues/8818
+ */
+final class MyEntity
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="App:AnotherClass")
+     */
+    private readonly ?Collection $items;
+
+    public function addItem(AnotherClass $myOtherEntity): void
+    {
+        $this->items->add($myOtherEntity);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Fixture\Annotation;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass;
+
+/**
+ * @see https://github.com/doctrine/orm/issues/8818
+ */
+final class MyEntity
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="App:AnotherClass")
+     */
+    private readonly ?Collection $items;
+
+    public function addItem(AnotherClass $myOtherEntity): void
+    {
+        $this->items->add($myOtherEntity);
+    }
+}
+
+?>

--- a/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Annotation/resolve_string_classes_with_unresolvable_class.php.inc
+++ b/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Annotation/resolve_string_classes_with_unresolvable_class.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Fixture\Annotation;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+final class MyEntity
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="UnresolvableClass")
+     */
+    private readonly ?Collection $items;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Fixture\Annotation;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+final class MyEntity
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="UnresolvableClass")
+     */
+    private readonly ?Collection $items;
+}
+
+?>

--- a/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Annotation/resolve_string_classes_without_leading_backslash.php.inc
+++ b/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Annotation/resolve_string_classes_without_leading_backslash.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Fixture\Annotation;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass;
+
+final class MyEntity
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass")
+     */
+    private readonly ?Collection $items;
+
+    public function addItem(AnotherClass $myOtherEntity): void
+    {
+        $this->items->add($myOtherEntity);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Fixture\Annotation;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass;
+
+final class MyEntity
+{
+    /**
+     * @ORM\ManyToOne(targetEntity=\Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass::class)
+     */
+    private readonly ?Collection $items;
+
+    public function addItem(AnotherClass $myOtherEntity): void
+    {
+        $this->items->add($myOtherEntity);
+    }
+}
+
+?>

--- a/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Attribute/doctrine_string_target_entity_to_class.php.inc
+++ b/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Attribute/doctrine_string_target_entity_to_class.php.inc
@@ -22,6 +22,8 @@ final class MyEntity
     private readonly ?Collection $items5;
     #[ORM\ManyToOne(targetEntity: "App:AnotherClass")]
     private readonly ?Collection $items6;
+    #[ORM\ManyToOne(targetEntity: "Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass")]
+    private readonly ?Collection $items7;
 
     public function addItem(AnotherClass $myOtherEntity): void
     {
@@ -55,6 +57,8 @@ final class MyEntity
     private readonly ?Collection $items5;
     #[ORM\ManyToOne(targetEntity: "App:AnotherClass")]
     private readonly ?Collection $items6;
+    #[ORM\ManyToOne(targetEntity: \Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass::class)]
+    private readonly ?Collection $items7;
 
     public function addItem(AnotherClass $myOtherEntity): void
     {

--- a/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Attribute/doctrine_string_target_entity_to_class.php.inc
+++ b/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Attribute/doctrine_string_target_entity_to_class.php.inc
@@ -18,12 +18,6 @@ final class MyEntity
     private readonly ?Collection $items3;
     #[ORM\OneToOne(mappedBy: 'class', targetEntity: "AnotherClass")]
     private readonly ?Collection $items4;
-    #[ORM\ManyToOne(targetEntity: "UnresolvableClass")]
-    private readonly ?Collection $items5;
-    #[ORM\ManyToOne(targetEntity: "App:AnotherClass")]
-    private readonly ?Collection $items6;
-    #[ORM\ManyToOne(targetEntity: "Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass")]
-    private readonly ?Collection $items7;
 
     public function addItem(AnotherClass $myOtherEntity): void
     {
@@ -53,12 +47,6 @@ final class MyEntity
     private readonly ?Collection $items3;
     #[ORM\OneToOne(mappedBy: 'class', targetEntity: \Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass::class)]
     private readonly ?Collection $items4;
-    #[ORM\ManyToOne(targetEntity: "UnresolvableClass")]
-    private readonly ?Collection $items5;
-    #[ORM\ManyToOne(targetEntity: "App:AnotherClass")]
-    private readonly ?Collection $items6;
-    #[ORM\ManyToOne(targetEntity: \Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass::class)]
-    private readonly ?Collection $items7;
 
     public function addItem(AnotherClass $myOtherEntity): void
     {

--- a/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Attribute/resolve_string_classes_with_entity_namespace.php.inc
+++ b/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Attribute/resolve_string_classes_with_entity_namespace.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Fixture\Attribute;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass;
+
+final class MyEntity
+{
+    #[ORM\ManyToOne(targetEntity: "App:AnotherClass")]
+    private readonly ?Collection $items;
+
+    public function addItem(AnotherClass $myOtherEntity): void
+    {
+        $this->items->add($myOtherEntity);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Fixture\Attribute;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass;
+
+final class MyEntity
+{
+    #[ORM\ManyToOne(targetEntity: "App:AnotherClass")]
+    private readonly ?Collection $items;
+
+    public function addItem(AnotherClass $myOtherEntity): void
+    {
+        $this->items->add($myOtherEntity);
+    }
+}
+
+?>

--- a/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Attribute/resolve_string_classes_with_unresolvable_class.php.inc
+++ b/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Attribute/resolve_string_classes_with_unresolvable_class.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Fixture\Attribute;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+final class MyEntity
+{
+    #[ORM\ManyToOne(targetEntity: "UnresolvableClass")]
+    private readonly ?Collection $items;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Fixture\Attribute;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+final class MyEntity
+{
+    #[ORM\ManyToOne(targetEntity: "UnresolvableClass")]
+    private readonly ?Collection $items;
+}
+
+?>

--- a/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Attribute/resolve_string_classes_without_leading_backslash.php.inc
+++ b/tests/Rector/Property/DoctrineTargetEntityStringToClassConstantRector/Fixture/Attribute/resolve_string_classes_without_leading_backslash.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Fixture\Attribute;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass;
+
+final class MyEntity
+{
+    #[ORM\ManyToOne(targetEntity: "Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass")]
+    private readonly ?Collection $items;
+
+    public function addItem(AnotherClass $myOtherEntity): void
+    {
+        $this->items->add($myOtherEntity);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Fixture\Attribute;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass;
+
+final class MyEntity
+{
+    #[ORM\ManyToOne(targetEntity: \Rector\Doctrine\Tests\Rector\Property\DoctrineTargetEntityStringToClassConstantRector\Source\AnotherClass::class)]
+    private readonly ?Collection $items;
+
+    public function addItem(AnotherClass $myOtherEntity): void
+    {
+        $this->items->add($myOtherEntity);
+    }
+}
+
+?>


### PR DESCRIPTION
In the past doctrine recommended using class strings with omitted leading backslash. Hence, we have to check again for that class with added backslash.
See https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/annotations-reference.html#entity for an example.

I think when configured a while back ago, class-strings without leading backslash is very common.