### PR TITLE
Update test for MakeEntitySetterNullabilityInSyncWithPropertyRector

### DIFF
--- a/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
+++ b/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
@@ -109,9 +109,7 @@ CODE_SAMPLE
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
-        $manyToOneAnnotationTagValueNode = $phpDocInfo->getByAnnotationClass(
-            'Doctrine\ORM\Mapping\ManyToOne'
-        );
+        $manyToOneAnnotationTagValueNode = $phpDocInfo->getByAnnotationClass('Doctrine\ORM\Mapping\ManyToOne');
 
         if (! $manyToOneAnnotationTagValueNode instanceof DoctrineAnnotationTagValueNode) {
             return null;

--- a/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
+++ b/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
@@ -163,6 +163,10 @@ CODE_SAMPLE
 
         $nullableNode = $joinColumnDoctrineAnnotationTagValueNode->getValue('nullable');
 
+        if (! $nullableNode instanceof ArrayItemNode) {
+            return true;
+        }
+
         return ! $nullableNode->value instanceof ConstExprFalseNode;
     }
 }

--- a/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
+++ b/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
@@ -9,8 +9,7 @@ use PhpParser\Node\ComplexType;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
-use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprNode;
-use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprTrueNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprFalseNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Doctrine\NodeAnalyzer\SetterClassMethodAnalyzer;
@@ -156,11 +155,7 @@ CODE_SAMPLE
         DoctrineAnnotationTagValueNode $joinColumnDoctrineAnnotationTagValueNode
     ): bool {
         $nullableNode = $joinColumnDoctrineAnnotationTagValueNode->getValue('nullable');
-        if (! $nullableNode instanceof ConstExprNode) {
-            // if the nullable explicit value is missing, by default the property is nullable
-            return true;
-        }
 
-        return $nullableNode instanceof ConstExprTrueNode;
+        return ! $nullableNode instanceof ConstExprFalseNode;
     }
 }

--- a/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
+++ b/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
@@ -105,11 +105,13 @@ CODE_SAMPLE
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
-        if (! $phpDocInfo->hasByAnnotationClass('Doctrine\ORM\Mapping\JoinColumn')) {
+        if (! $phpDocInfo->hasByAnnotationClass('Doctrine\ORM\Mapping\ManyToOne')) {
             return null;
         }
 
-        if (false) { // TODO JoinColumn nullable true or not set should return null here
+        $joinColumnTagValueNode = $phpDocInfo->getByAnnotationClass('Doctrine\ORM\Mapping\JoinColumn');
+
+        if (! $joinColumnTagValueNode && ! $joinColumnTagValueNode->getAttribute('nullable')) {
             return null;
         }
 

--- a/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
+++ b/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
@@ -161,12 +161,12 @@ CODE_SAMPLE
             return true;
         }
 
-        $nullableNode = $joinColumnDoctrineAnnotationTagValueNode->getValue('nullable');
+        $arrayItemNode = $joinColumnDoctrineAnnotationTagValueNode->getValue('nullable');
 
-        if (! $nullableNode instanceof ArrayItemNode) {
+        if (! $arrayItemNode instanceof ArrayItemNode) {
             return true;
         }
 
-        return ! $nullableNode->value instanceof ConstExprFalseNode;
+        return ! $arrayItemNode->value instanceof ConstExprFalseNode;
     }
 }

--- a/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
+++ b/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\ComplexType;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
-use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprFalseNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprTrueNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
@@ -110,7 +109,9 @@ CODE_SAMPLE
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
-        $joinColumnDoctrineAnnotationTagValueNode = $phpDocInfo->getByAnnotationClass('Doctrine\ORM\Mapping\JoinColumn');
+        $joinColumnDoctrineAnnotationTagValueNode = $phpDocInfo->getByAnnotationClass(
+            'Doctrine\ORM\Mapping\JoinColumn'
+        );
 
         if (! $joinColumnDoctrineAnnotationTagValueNode instanceof DoctrineAnnotationTagValueNode) {
             // skip if there does not appear any join column
@@ -151,8 +152,9 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function isJoinColumnNullable(DoctrineAnnotationTagValueNode $joinColumnDoctrineAnnotationTagValueNode): bool
-    {
+    private function isJoinColumnNullable(
+        DoctrineAnnotationTagValueNode $joinColumnDoctrineAnnotationTagValueNode
+    ): bool {
         $nullableNode = $joinColumnDoctrineAnnotationTagValueNode->getValue('nullable');
         if (! $nullableNode instanceof ConstExprNode) {
             // if the nullable explicit value is missing, by default the property is nullable

--- a/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
+++ b/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprFalseNode;
+use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
@@ -162,6 +163,6 @@ CODE_SAMPLE
 
         $nullableNode = $joinColumnDoctrineAnnotationTagValueNode->getValue('nullable');
 
-        return ! $nullableNode instanceof ConstExprFalseNode;
+        return ! $nullableNode->value instanceof ConstExprFalseNode;
     }
 }

--- a/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
+++ b/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
@@ -43,6 +43,7 @@ class Product
 {
     /**
      * @ORM\ManyToOne(targetEntity="AnotherEntity")
+     * @ORM\JoinColumn(nullable=false)
      */
     private $anotherEntity;
 
@@ -64,6 +65,7 @@ class Product
 {
     /**
      * @ORM\ManyToOne(targetEntity="AnotherEntity")
+     * @ORM\JoinColumn(nullable=false)
      */
     private $anotherEntity;
 
@@ -103,7 +105,11 @@ CODE_SAMPLE
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
-        if (! $phpDocInfo->hasByAnnotationClass('Doctrine\ORM\Mapping\ManyToOne')) {
+        if (! $phpDocInfo->hasByAnnotationClass('Doctrine\ORM\Mapping\JoinColumn')) {
+            return null;
+        }
+
+        if (false) { // TODO JoinColumn nullable true or not set should return null here
             return null;
         }
 

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/fixture.php.inc
@@ -10,35 +10,35 @@ use Doctrine\ORM\Mapping as ORM;
 class Product
 {
     /**
-     * @ORM\ManyToOne(targetEntity="AnotherEntity")
+     * @ORM\ManyToOne(targetEntity="DefaultEntity")
      */
-    private $anotherEntity;
+    private $defaultEntity;
 
     /**
-     * @ORM\ManyToOne(targetEntity="AnotherEntity2")
+     * @ORM\ManyToOne(targetEntity="NotNullableEntity")
      * @ORM\JoinColumn(nullable=false)
      */
-    private $anotherEntity2;
+    private $notNullableEntity;
 
     /**
-     * @ORM\ManyToOne(targetEntity="AnotherEntity2")
+     * @ORM\ManyToOne(targetEntity="NullableEntity")
      * @ORM\JoinColumn(nullable=true)
      */
-    private $anotherEntity3;
+    private $nullableEntity;
 
-    public function setAnotherEntity(AnotherEntity $anotherEntity)
+    public function setDefaultEntity(DefaultEntity $defaultEntity)
     {
-        $this->anotherEntity = $anotherEntity;
+        $this->defaultEntity = $defaultEntity;
     }
 
-    public function setAnotherEntity2(?AnotherEntity $anotherEntity2)
+    public function setNotNullableEntity(?NotNullableEntity $notNullableEntity)
     {
-        $this->anotherEntity2 = $anotherEntity2;
+        $this->notNullableEntity = $notNullableEntity;
     }
 
-    public function setAnotherEntity3(AnotherEntity2 $anotherEntity3)
+    public function setNullableEntity(NullableEntity $nullableEntity)
     {
-        $this->anotherEntity3 = $anotherEntity3;
+        $this->nullableEntity = $nullableEntity;
     }
 }
 
@@ -56,35 +56,35 @@ use Doctrine\ORM\Mapping as ORM;
 class Product
 {
     /**
-     * @ORM\ManyToOne(targetEntity="AnotherEntity")
+     * @ORM\ManyToOne(targetEntity="DefaultEntity")
      */
-    private $anotherEntity;
+    private $defaultEntity;
 
     /**
-     * @ORM\ManyToOne(targetEntity="AnotherEntity2")
+     * @ORM\ManyToOne(targetEntity="NotNullableEntity")
      * @ORM\JoinColumn(nullable=false)
      */
-    private $anotherEntity2;
+    private $notNullableEntity;
 
     /**
-     * @ORM\ManyToOne(targetEntity="AnotherEntity2")
+     * @ORM\ManyToOne(targetEntity="NullableEntity")
      * @ORM\JoinColumn(nullable=true)
      */
-    private $anotherEntity3;
+    private $nullableEntity;
 
-    public function setAnotherEntity(?AnotherEntity $anotherEntity)
+    public function setDefaultEntity(?DefaultEntity $defaultEntity)
     {
-        $this->anotherEntity = $anotherEntity;
+        $this->defaultEntity = $defaultEntity;
     }
 
-    public function setAnotherEntity2(AnotherEntity $anotherEntity2)
+    public function setNotNullableEntity(NotNullableEntity $notNullableEntity)
     {
-        $this->anotherEntity2 = $anotherEntity2;
+        $this->notNullableEntity = $notNullableEntity;
     }
 
-    public function setAnotherEntity3(?AnotherEntity2 $anotherEntity3)
+    public function setNullableEntity(?NullableEntity $nullableEntity)
     {
-        $this->anotherEntity3 = $anotherEntity3;
+        $this->nullableEntity = $nullableEntity;
     }
 }
 

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/fixture.php.inc
@@ -14,9 +14,31 @@ class Product
      */
     private $anotherEntity;
 
-    public function setAnotherEntity(?AnotherEntity $anotherEntity)
+    /**
+     * @ORM\ManyToOne(targetEntity="AnotherEntity2")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $anotherEntity2;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="AnotherEntity2")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $anotherEntity3;
+
+    public function setAnotherEntity(AnotherEntity $anotherEntity)
     {
         $this->anotherEntity = $anotherEntity;
+    }
+
+    public function setAnotherEntity2(?AnotherEntity $anotherEntity2)
+    {
+        $this->anotherEntity2 = $anotherEntity2;
+    }
+
+    public function setAnotherEntity3(AnotherEntity2 $anotherEntity3)
+    {
+        $this->anotherEntity3 = $anotherEntity3;
     }
 }
 
@@ -38,9 +60,31 @@ class Product
      */
     private $anotherEntity;
 
-    public function setAnotherEntity(AnotherEntity $anotherEntity)
+    /**
+     * @ORM\ManyToOne(targetEntity="AnotherEntity2")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $anotherEntity2;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="AnotherEntity2")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $anotherEntity3;
+
+    public function setAnotherEntity(?AnotherEntity $anotherEntity)
     {
         $this->anotherEntity = $anotherEntity;
+    }
+
+    public function setAnotherEntity2(AnotherEntity $anotherEntity2)
+    {
+        $this->anotherEntity2 = $anotherEntity2;
+    }
+
+    public function setAnotherEntity3(?AnotherEntity2 $anotherEntity3)
+    {
+        $this->anotherEntity3 = $anotherEntity3;
     }
 }
 

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default.php.inc
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class Product
+class ManyToOneDefault
 {
     /**
      * @ORM\ManyToOne(targetEntity="DefaultEntity")
@@ -31,7 +31,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class Product
+class ManyToOneDefault
 {
     /**
      * @ORM\ManyToOne(targetEntity="DefaultEntity")

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Product
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="DefaultEntity")
+     */
+    private $defaultEntity;
+
+    public function setDefaultEntity(DefaultEntity $defaultEntity)
+    {
+        $this->defaultEntity = $defaultEntity;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Product
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="DefaultEntity")
+     */
+    private $defaultEntity;
+
+    public function setDefaultEntity(?DefaultEntity $defaultEntity)
+    {
+        $this->defaultEntity = $defaultEntity;
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default.php.inc
@@ -21,27 +21,3 @@ class ManyToOneDefault
 }
 
 ?>
------
-<?php
-
-namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
-
-use Doctrine\ORM\Mapping as ORM;
-
-/**
- * @ORM\Entity()
- */
-class ManyToOneDefault
-{
-    /**
-     * @ORM\ManyToOne(targetEntity="DefaultEntity")
-     */
-    private $defaultEntity;
-
-    public function setDefaultEntity(DefaultEntity $defaultEntity)
-    {
-        $this->defaultEntity = $defaultEntity;
-    }
-}
-
-?>

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default.php.inc
@@ -38,7 +38,7 @@ class Product
      */
     private $defaultEntity;
 
-    public function setDefaultEntity(?DefaultEntity $defaultEntity)
+    public function setDefaultEntity(DefaultEntity $defaultEntity)
     {
         $this->defaultEntity = $defaultEntity;
     }

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default_setter_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default_setter_nullable.php.inc
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class Product
+class ManyToOneDefaultSetterNullable
 {
     /**
      * @ORM\ManyToOne(targetEntity="DefaultEntity")
@@ -31,7 +31,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class Product
+class ManyToOneDefaultSetterNullable
 {
     /**
      * @ORM\ManyToOne(targetEntity="DefaultEntity")

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default_setter_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default_setter_nullable.php.inc
@@ -21,27 +21,3 @@ class ManyToOneDefaultSetterNullable
 }
 
 ?>
------
-<?php
-
-namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
-
-use Doctrine\ORM\Mapping as ORM;
-
-/**
- * @ORM\Entity()
- */
-class ManyToOneDefaultSetterNullable
-{
-    /**
-     * @ORM\ManyToOne(targetEntity="DefaultEntity")
-     */
-    private $defaultEntity;
-
-    public function setDefaultEntity(?DefaultEntity $defaultEntity)
-    {
-        $this->defaultEntity = $defaultEntity;
-    }
-}
-
-?>

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default_setter_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_default_setter_nullable.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Product
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="DefaultEntity")
+     */
+    private $defaultEntity;
+
+    public function setDefaultEntity(?DefaultEntity $defaultEntity)
+    {
+        $this->defaultEntity = $defaultEntity;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Product
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="DefaultEntity")
+     */
+    private $defaultEntity;
+
+    public function setDefaultEntity(?DefaultEntity $defaultEntity)
+    {
+        $this->defaultEntity = $defaultEntity;
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_not_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_not_nullable.php.inc
@@ -10,35 +10,14 @@ use Doctrine\ORM\Mapping as ORM;
 class Product
 {
     /**
-     * @ORM\ManyToOne(targetEntity="DefaultEntity")
-     */
-    private $defaultEntity;
-
-    /**
      * @ORM\ManyToOne(targetEntity="NotNullableEntity")
      * @ORM\JoinColumn(nullable=false)
      */
     private $notNullableEntity;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="NullableEntity")
-     * @ORM\JoinColumn(nullable=true)
-     */
-    private $nullableEntity;
-
-    public function setDefaultEntity(DefaultEntity $defaultEntity)
-    {
-        $this->defaultEntity = $defaultEntity;
-    }
-
     public function setNotNullableEntity(?NotNullableEntity $notNullableEntity)
     {
         $this->notNullableEntity = $notNullableEntity;
-    }
-
-    public function setNullableEntity(NullableEntity $nullableEntity)
-    {
-        $this->nullableEntity = $nullableEntity;
     }
 }
 
@@ -56,35 +35,14 @@ use Doctrine\ORM\Mapping as ORM;
 class Product
 {
     /**
-     * @ORM\ManyToOne(targetEntity="DefaultEntity")
-     */
-    private $defaultEntity;
-
-    /**
      * @ORM\ManyToOne(targetEntity="NotNullableEntity")
      * @ORM\JoinColumn(nullable=false)
      */
     private $notNullableEntity;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="NullableEntity")
-     * @ORM\JoinColumn(nullable=true)
-     */
-    private $nullableEntity;
-
-    public function setDefaultEntity(?DefaultEntity $defaultEntity)
-    {
-        $this->defaultEntity = $defaultEntity;
-    }
-
     public function setNotNullableEntity(NotNullableEntity $notNullableEntity)
     {
         $this->notNullableEntity = $notNullableEntity;
-    }
-
-    public function setNullableEntity(?NullableEntity $nullableEntity)
-    {
-        $this->nullableEntity = $nullableEntity;
     }
 }
 

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_not_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_not_nullable.php.inc
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class Product
+class ManyToOneNotNullable
 {
     /**
      * @ORM\ManyToOne(targetEntity="NotNullableEntity")
@@ -32,7 +32,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class Product
+class ManyToOneNotNullable
 {
     /**
      * @ORM\ManyToOne(targetEntity="NotNullableEntity")

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_not_nullable_setter_not_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_not_nullable_setter_not_nullable.php.inc
@@ -22,28 +22,3 @@ class ManyToOneNotNullableSetterNotNullable
 }
 
 ?>
------
-<?php
-
-namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
-
-use Doctrine\ORM\Mapping as ORM;
-
-/**
- * @ORM\Entity()
- */
-class ManyToOneNotNullableSetterNotNullable
-{
-    /**
-     * @ORM\ManyToOne(targetEntity="NotNullableEntity")
-     * @ORM\JoinColumn(nullable=false)
-     */
-    private $notNullableEntity;
-
-    public function setNotNullableEntity(NotNullableEntity $notNullableEntity)
-    {
-        $this->notNullableEntity = $notNullableEntity;
-    }
-}
-
-?>

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_not_nullable_setter_not_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_not_nullable_setter_not_nullable.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Product
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="NotNullableEntity")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $notNullableEntity;
+
+    public function setNotNullableEntity(NotNullableEntity $notNullableEntity)
+    {
+        $this->notNullableEntity = $notNullableEntity;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Product
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="NotNullableEntity")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $notNullableEntity;
+
+    public function setNotNullableEntity(NotNullableEntity $notNullableEntity)
+    {
+        $this->notNullableEntity = $notNullableEntity;
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_not_nullable_setter_not_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_not_nullable_setter_not_nullable.php.inc
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class Product
+class ManyToOneNotNullableSetterNotNullable
 {
     /**
      * @ORM\ManyToOne(targetEntity="NotNullableEntity")
@@ -32,7 +32,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class Product
+class ManyToOneNotNullableSetterNotNullable
 {
     /**
      * @ORM\ManyToOne(targetEntity="NotNullableEntity")

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable.php.inc
@@ -22,28 +22,3 @@ class ManyToOneNullable
 }
 
 ?>
------
-<?php
-
-namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
-
-use Doctrine\ORM\Mapping as ORM;
-
-/**
- * @ORM\Entity()
- */
-class ManyToOneNullable
-{
-    /**
-     * @ORM\ManyToOne(targetEntity="NullableEntity")
-     * @ORM\JoinColumn(nullable=true)
-     */
-    private $nullableEntity;
-
-    public function setNullableEntity(NullableEntity $nullableEntity)
-    {
-        $this->nullableEntity = $nullableEntity;
-    }
-}
-
-?>

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Product
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="NullableEntity")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $nullableEntity;
+
+    public function setNullableEntity(NullableEntity $nullableEntity)
+    {
+        $this->nullableEntity = $nullableEntity;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Product
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="NullableEntity")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $nullableEntity;
+
+    public function setNullableEntity(?NullableEntity $nullableEntity)
+    {
+        $this->nullableEntity = $nullableEntity;
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable.php.inc
@@ -40,7 +40,7 @@ class Product
      */
     private $nullableEntity;
 
-    public function setNullableEntity(?NullableEntity $nullableEntity)
+    public function setNullableEntity(NullableEntity $nullableEntity)
     {
         $this->nullableEntity = $nullableEntity;
     }

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable.php.inc
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class Product
+class ManyToOneNullable
 {
     /**
      * @ORM\ManyToOne(targetEntity="NullableEntity")
@@ -32,7 +32,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class Product
+class ManyToOneNullable
 {
     /**
      * @ORM\ManyToOne(targetEntity="NullableEntity")

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable_setter_not_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable_setter_not_nullable.php.inc
@@ -22,28 +22,3 @@ class ManyToOneNullableSetterNotNullable
 }
 
 ?>
------
-<?php
-
-namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
-
-use Doctrine\ORM\Mapping as ORM;
-
-/**
- * @ORM\Entity()
- */
-class ManyToOneNullableSetterNotNullable
-{
-    /**
-     * @ORM\ManyToOne(targetEntity="NullableEntity")
-     * @ORM\JoinColumn(nullable=true)
-     */
-    private $nullableEntity;
-
-    public function setNullableEntity(?NullableEntity $nullableEntity)
-    {
-        $this->nullableEntity = $nullableEntity;
-    }
-}
-
-?>

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable_setter_not_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable_setter_not_nullable.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Product
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="NullableEntity")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $nullableEntity;
+
+    public function setNullableEntity(?NullableEntity $nullableEntity)
+    {
+        $this->nullableEntity = $nullableEntity;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\MakeEntitySetterNullabilityInSyncWithPropertyRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Product
+{
+    /**
+     * @ORM\ManyToOne(targetEntity="NullableEntity")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $nullableEntity;
+
+    public function setNullableEntity(?NullableEntity $nullableEntity)
+    {
+        $this->nullableEntity = $nullableEntity;
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable_setter_not_nullable.php.inc
+++ b/tests/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector/Fixture/many_to_one_nullable_setter_not_nullable.php.inc
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class Product
+class ManyToOneNullableSetterNotNullable
 {
     /**
      * @ORM\ManyToOne(targetEntity="NullableEntity")
@@ -32,7 +32,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity()
  */
-class Product
+class ManyToOneNullableSetterNotNullable
 {
     /**
      * @ORM\ManyToOne(targetEntity="NullableEntity")


### PR DESCRIPTION
Reproducer the `MakeEntitySetterNullabilityInSyncWithPropertyRector` currently is implemented uncorrectly. By default a `ManyToOne` is `nullable="true"` see https://github.com/doctrine/orm/blob/5283e1441cc020d526d4842c6bfa21c1a500886d/lib/Doctrine/ORM/Mapping/JoinColumn.php#L28 and so currently this rules accidently removes `?` from a setter where it should not do it.

PS: This error does not happening when using `Attributes` but maybe not a equal rule for attributes does exist?

---

EDIT @TomasVotruba : Fixes https://github.com/rectorphp/rector/issues/7353, closes https://github.com/rectorphp/rector-doctrine/pull/123