### PR TITLE
Report RemoveRedundantDefaultClassAnnotationValuesRector and RemoveRedundantDefaultPropertyAnnotationValuesRectoronly if node has changed

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -44,3 +44,6 @@ parameters:
             path: "src/Rector/Class_/SluggableBehaviorRector.php"
             message: '#Method call return value that should be used, but is not#'
 
+
+        # these methods return "true" on changed, "false" on no change
+        - '#Method "clear(.*?)\(\)" returns bool type, so the name should start with is/has/was#'

--- a/src/NodeAnalyzer/AttributeCleaner.php
+++ b/src/NodeAnalyzer/AttributeCleaner.php
@@ -27,11 +27,13 @@ final class AttributeCleaner
         ClassMethod | Property | ClassLike | Param $node,
         string $attributeClass,
         string $argName
-    ): void {
+    ): bool {
         $attribute = $this->attributeFinder->findAttributeByClass($node, $attributeClass);
         if (! $attribute instanceof Attribute) {
-            return;
+            return false;
         }
+
+        $hasChanged = false;
 
         foreach ($attribute->args as $key => $arg) {
             if (! $arg->name instanceof Node) {
@@ -44,6 +46,9 @@ final class AttributeCleaner
 
             // remove attribute
             unset($attribute->args[$key]);
+            $hasChanged = true;
         }
+
+        return $hasChanged;
     }
 }

--- a/src/NodeAnalyzer/AttributeCleaner.php
+++ b/src/NodeAnalyzer/AttributeCleaner.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
+use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\NodeNameResolver\NodeNameResolver;
 
 /**
@@ -27,13 +28,11 @@ final class AttributeCleaner
         ClassMethod | Property | ClassLike | Param $node,
         string $attributeClass,
         string $argName
-    ): bool {
+    ): void {
         $attribute = $this->attributeFinder->findAttributeByClass($node, $attributeClass);
         if (! $attribute instanceof Attribute) {
-            return false;
+            throw new ShouldNotHappenException();
         }
-
-        $hasChanged = false;
 
         foreach ($attribute->args as $key => $arg) {
             if (! $arg->name instanceof Node) {
@@ -46,9 +45,6 @@ final class AttributeCleaner
 
             // remove attribute
             unset($attribute->args[$key]);
-            $hasChanged = true;
         }
-
-        return $hasChanged;
     }
 }

--- a/src/NodeManipulator/DoctrineItemDefaultValueManipulator.php
+++ b/src/NodeManipulator/DoctrineItemDefaultValueManipulator.php
@@ -12,7 +12,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 
 final class DoctrineItemDefaultValueManipulator
 {
-    public function remove(
+    public function clearDoctrineAnnotationTagValueNode(
         PhpDocInfo $phpDocInfo,
         DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode,
         string $item,

--- a/src/NodeManipulator/DoctrineItemDefaultValueManipulator.php
+++ b/src/NodeManipulator/DoctrineItemDefaultValueManipulator.php
@@ -17,14 +17,15 @@ final class DoctrineItemDefaultValueManipulator
         DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode,
         string $item,
         string|bool|int $defaultValue
-    ): void {
+    ): bool {
         if (! $this->hasItemWithDefaultValue($doctrineAnnotationTagValueNode, $item, $defaultValue)) {
-            return;
+            return false;
         }
 
         $doctrineAnnotationTagValueNode->removeValue($item);
 
         $phpDocInfo->markAsChanged();
+        return true;
     }
 
     private function hasItemWithDefaultValue(

--- a/src/Rector/Class_/RemoveRedundantDefaultClassAnnotationValuesRector.php
+++ b/src/Rector/Class_/RemoveRedundantDefaultClassAnnotationValuesRector.php
@@ -74,7 +74,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $hasChanged = $this->doctrineItemDefaultValueManipulator->remove(
+        $hasChanged = $this->doctrineItemDefaultValueManipulator->clearDoctrineAnnotationTagValueNode(
             $phpDocInfo,
             $doctrineAnnotationTagValueNode,
             'readOnly',

--- a/src/Rector/Class_/RemoveRedundantDefaultClassAnnotationValuesRector.php
+++ b/src/Rector/Class_/RemoveRedundantDefaultClassAnnotationValuesRector.php
@@ -67,30 +67,24 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $this->refactorClassAnnotations($node);
-
-        return $node;
-    }
-
-    private function refactorClassAnnotations(Class_ $class): void
-    {
-        $this->refactorEntityAnnotation($class);
-    }
-
-    private function refactorEntityAnnotation(Class_ $class): void
-    {
-        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($class);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         $doctrineAnnotationTagValueNode = $phpDocInfo->getByAnnotationClass('Doctrine\ORM\Mapping\Entity');
         if (! $doctrineAnnotationTagValueNode instanceof DoctrineAnnotationTagValueNode) {
-            return;
+            return null;
         }
 
-        $this->doctrineItemDefaultValueManipulator->remove(
+        $hasChanged = $this->doctrineItemDefaultValueManipulator->remove(
             $phpDocInfo,
             $doctrineAnnotationTagValueNode,
             'readOnly',
             false
         );
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
     }
 }

--- a/src/Rector/Property/RemoveRedundantDefaultPropertyAnnotationValuesRector.php
+++ b/src/Rector/Property/RemoveRedundantDefaultPropertyAnnotationValuesRector.php
@@ -109,7 +109,8 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $this->refactorPropertyAnnotations($node);
+        $hasPhpDocInfoChanged = $this->refactorPropertyAnnotations($node);
+        $hasAttributeChanged = false;
 
         foreach ($this->defaultAnnotationArgValues as $defaultAnnotationArgValue) {
             $argExpr = $this->attributeFinder->findAttributeByClassArgByName(
@@ -131,34 +132,48 @@ CODE_SAMPLE
                 $defaultAnnotationArgValue->getAnnotationClass(),
                 $defaultAnnotationArgValue->getArgName()
             );
+
+            $hasAttributeChanged = true;
         }
 
-        return $node;
+        if ($hasPhpDocInfoChanged || $hasAttributeChanged) {
+            return $node;
+        }
+
+        return null;
     }
 
-    private function refactorPropertyAnnotations(Property $property): void
+    private function refactorPropertyAnnotations(Property $property): bool
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($property);
+        if (! $phpDocInfo instanceof PhpDocInfo) {
+            return false;
+        }
 
-        if ($phpDocInfo instanceof PhpDocInfo) {
-            foreach ($this->defaultAnnotationArgValues as $defaultAnnotationArgValue) {
-                $this->refactorAnnotation($phpDocInfo, $defaultAnnotationArgValue);
+        $hasPropertyChanged = false;
+
+        foreach ($this->defaultAnnotationArgValues as $defaultAnnotationArgValue) {
+            $hasAnnotationChanged = $this->refactorAnnotation($phpDocInfo, $defaultAnnotationArgValue);
+            if ($hasAnnotationChanged) {
+                $hasPropertyChanged = true;
             }
         }
+
+        return $hasPropertyChanged;
     }
 
     private function refactorAnnotation(
         PhpDocInfo $phpDocInfo,
         DefaultAnnotationArgValue $defaultAnnotationArgValue
-    ): void {
+    ): bool {
         $doctrineAnnotationTagValueNode = $phpDocInfo->getByAnnotationClass(
             $defaultAnnotationArgValue->getAnnotationClass()
         );
         if (! $doctrineAnnotationTagValueNode instanceof DoctrineAnnotationTagValueNode) {
-            return;
+            return false;
         }
 
-        $this->doctrineItemDefaultValueManipulator->remove(
+        return $this->doctrineItemDefaultValueManipulator->remove(
             $phpDocInfo,
             $doctrineAnnotationTagValueNode,
             $defaultAnnotationArgValue->getArgName(),

--- a/src/Rector/Property/RemoveRedundantDefaultPropertyAnnotationValuesRector.php
+++ b/src/Rector/Property/RemoveRedundantDefaultPropertyAnnotationValuesRector.php
@@ -109,7 +109,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $hasPhpDocInfoChanged = $this->refactorPropertyAnnotations($node);
+        $hasPhpDocInfoChanged = $this->clearPropertyAnnotations($node);
         $hasAttributeChanged = false;
 
         foreach ($this->defaultAnnotationArgValues as $defaultAnnotationArgValue) {
@@ -143,7 +143,7 @@ CODE_SAMPLE
         return null;
     }
 
-    private function refactorPropertyAnnotations(Property $property): bool
+    private function clearPropertyAnnotations(Property $property): bool
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($property);
         if (! $phpDocInfo instanceof PhpDocInfo) {
@@ -153,7 +153,7 @@ CODE_SAMPLE
         $hasPropertyChanged = false;
 
         foreach ($this->defaultAnnotationArgValues as $defaultAnnotationArgValue) {
-            $hasAnnotationChanged = $this->refactorAnnotation($phpDocInfo, $defaultAnnotationArgValue);
+            $hasAnnotationChanged = $this->clearAnnotation($phpDocInfo, $defaultAnnotationArgValue);
             if ($hasAnnotationChanged) {
                 $hasPropertyChanged = true;
             }
@@ -162,7 +162,7 @@ CODE_SAMPLE
         return $hasPropertyChanged;
     }
 
-    private function refactorAnnotation(
+    private function clearAnnotation(
         PhpDocInfo $phpDocInfo,
         DefaultAnnotationArgValue $defaultAnnotationArgValue
     ): bool {
@@ -173,7 +173,7 @@ CODE_SAMPLE
             return false;
         }
 
-        return $this->doctrineItemDefaultValueManipulator->remove(
+        return $this->doctrineItemDefaultValueManipulator->clearDoctrineAnnotationTagValueNode(
             $phpDocInfo,
             $doctrineAnnotationTagValueNode,
             $defaultAnnotationArgValue->getArgName(),


### PR DESCRIPTION
Discovered in https://github.com/rectorphp/rector/issues/7353