### PR TITLE
fix(7379): Support converting override annotations to attributes

### DIFF
--- a/config/sets/doctrine-annotations-to-attributes.php
+++ b/config/sets/doctrine-annotations-to-attributes.php
@@ -59,5 +59,12 @@ return static function (RectorConfig $rectorConfig): void {
         new AnnotationToAttribute('Doctrine\ORM\Mapping\PreUpdate'),
         new AnnotationToAttribute('Doctrine\ORM\Mapping\Cache'),
         new AnnotationToAttribute('Doctrine\ORM\Mapping\EntityListeners'),
+
+        // Overrides
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\AssociationOverrides'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\AssociationOverride'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\AttributeOverrides'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\AttributeOverride'),
+
     ]);
 };

--- a/tests/Set/DoctrineORM29Set/FixturePhp81/overrides.php.inc
+++ b/tests/Set/DoctrineORM29Set/FixturePhp81/overrides.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Set\DoctrineORM29Set\FixturePhp81;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\AssociationOverrides({
+ *     @ORM\AssociationOverride(name="propertyA", inversedBy="propertyB")
+ * })
+ * @ORM\AttributeOverrides(
+ *     @ORM\AttributeOverride(name="id", column=@ORM\Column(type="integer"))
+ * )
+ */
+class Overrides
+{
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Set\DoctrineORM29Set\FixturePhp81;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\AssociationOverrides([new ORM\AssociationOverride(name: 'propertyA', inversedBy: 'propertyB')])]
+#[ORM\AttributeOverrides([new ORM\AttributeOverride(name: 'id', column: new ORM\Column(type: 'integer'))])]
+class Overrides
+{
+}
+
+?>

--- a/tests/Set/DoctrineORM29Set/FixturePhp81/overrides.php.inc
+++ b/tests/Set/DoctrineORM29Set/FixturePhp81/overrides.php.inc
@@ -10,9 +10,9 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\AssociationOverrides({
  *     @ORM\AssociationOverride(name="propertyA", inversedBy="propertyB")
  * })
- * @ORM\AttributeOverrides(
+ * @ORM\AttributeOverrides({
  *     @ORM\AttributeOverride(name="id", column=@ORM\Column(type="integer"))
- * )
+ * })
  */
 class Overrides
 {


### PR DESCRIPTION
Fixes: #7379

Adds support for converting the following annotations to attributes
- `Doctrine\ORM\Mapping\AssociationOverrides`
- `Doctrine\ORM\Mapping\AssociationOverride`
- `Doctrine\ORM\Mapping\AttributeOverrides`
- `Doctrine\ORM\Mapping\AttributeOverride`

ToDo: fix converting the properties of the `AttributeOverrides` annotation.