### PR TITLE
[Doctrine] Skip join columns with Array of Join Column on RemoveRedundantDefaultPropertyAnnotationValuesRector

### DIFF
--- a/src/NodeManipulator/DoctrineItemDefaultValueManipulator.php
+++ b/src/NodeManipulator/DoctrineItemDefaultValueManipulator.php
@@ -10,6 +10,7 @@ use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprTrueNode;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\ValueObject\PhpDocAttributeKey;
 
 final class DoctrineItemDefaultValueManipulator
 {
@@ -20,6 +21,11 @@ final class DoctrineItemDefaultValueManipulator
         string|bool|int $defaultValue
     ): bool {
         if (! $this->hasItemWithDefaultValue($doctrineAnnotationTagValueNode, $item, $defaultValue)) {
+            return false;
+        }
+
+        $parent = $doctrineAnnotationTagValueNode->getAttribute(PhpDocAttributeKey::PARENT);
+        if ($parent instanceof ArrayItemNode) {
             return false;
         }
 

--- a/tests/Rector/Property/RemoveRedundantDefaultPropertyAnnotationValuesRector/Fixture/join_columns_with_array_of_join_column.php.inc
+++ b/tests/Rector/Property/RemoveRedundantDefaultPropertyAnnotationValuesRector/Fixture/join_columns_with_array_of_join_column.php.inc
@@ -1,17 +1,14 @@
 <?php
 
-namespace App\Entity;
+namespace Rector\Tests\Doctrine\Rector\Property\RemoveRedundantDefaultPropertyAnnotationValuesRector\Fixture;
 
 use Doctrine\ORM\Mapping as ORM;
-
 
 /**
  * Class Teste.
  *
  * @ORM\Entity()
  */
-namespace Rector\Tests\Doctrine\Rector\Property\RemoveRedundantDefaultPropertyAnnotationValuesRector\Fixture;
-
 class Teste
 {
     /**

--- a/tests/Rector/Property/RemoveRedundantDefaultPropertyAnnotationValuesRector/Fixture/join_columns_with_array_of_join_column.php.inc
+++ b/tests/Rector/Property/RemoveRedundantDefaultPropertyAnnotationValuesRector/Fixture/join_columns_with_array_of_join_column.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+
+/**
+ * Class Teste.
+ *
+ * @ORM\Entity()
+ */
+namespace Rector\Tests\Doctrine\Rector\Property\RemoveRedundantDefaultPropertyAnnotationValuesRector\Fixture;
+
+class Teste
+{
+    /**
+     * @var InventoryLocation
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\InventoryLocation", cascade={"persist"})
+     * @ORM\JoinColumns({
+     *   @ORM\JoinColumn(name="inventory_location_id", referencedColumnName="id")
+     * })
+     */
+    private $inventoryLocation;
+
+    public function getInventoryLocation(): ?InventoryLocation
+    {
+        return $this->inventoryLocation;
+    }
+
+    public function setInventoryLocation(?InventoryLocation $inventoryLocation): self
+    {
+        $this->inventoryLocation = $inventoryLocation;
+
+        return $this;
+    }
+}
+?>

--- a/tests/Rector/Property/RemoveRedundantDefaultPropertyAnnotationValuesRector/Fixture/skip_join_columns_with_array_of_join_column.php.inc
+++ b/tests/Rector/Property/RemoveRedundantDefaultPropertyAnnotationValuesRector/Fixture/skip_join_columns_with_array_of_join_column.php.inc
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\Entity()
  */
-class Teste
+class SkipJoinCOlumnsWIthArrayOfOfJoinColumn
 {
     /**
      * @var InventoryLocation


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-doctrine/pull/136
Fixes https://github.com/rectorphp/rector-doctrine/issues/132