### PR TITLE
[DoctrineCodeQuality] Correctly set constants for OrderBy values

### DIFF
--- a/config/sets/doctrine-code-quality.php
+++ b/config/sets/doctrine-code-quality.php
@@ -11,6 +11,7 @@ use Rector\Doctrine\CodeQuality\Rector\Property\ChangeBigIntEntityPropertyToIntT
 use Rector\Doctrine\CodeQuality\Rector\Property\CorrectDefaultTypesOnEntityPropertyRector;
 use Rector\Doctrine\CodeQuality\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector;
 use Rector\Doctrine\CodeQuality\Rector\Property\MakeEntityDateTimePropertyDateTimeInterfaceRector;
+use Rector\Doctrine\CodeQuality\Rector\Property\OrderByKeyToClassConstRector;
 use Rector\Doctrine\CodeQuality\Rector\Property\TypedPropertyFromColumnTypeRector;
 use Rector\Doctrine\CodeQuality\Rector\Property\TypedPropertyFromDoctrineCollectionRector;
 use Rector\Doctrine\CodeQuality\Rector\Property\TypedPropertyFromToManyRelationTypeRector;
@@ -34,6 +35,8 @@ return static function (RectorConfig $rectorConfig): void {
         TypedPropertyFromToOneRelationTypeRector::class,
         TypedPropertyFromToManyRelationTypeRector::class,
         TypedPropertyFromDoctrineCollectionRector::class,
+
+        OrderByKeyToClassConstRector::class,
     ]);
 
     $rectorConfig->ruleWithConfiguration(AttributeKeyToClassConstFetchRector::class, [

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 14 Rules Overview
+# 15 Rules Overview
 
 ## ChangeBigIntEntityPropertyToIntTypeRector
 
@@ -213,6 +213,26 @@ Move default value for entity property to constructor, the safest place
 +        $this->when = new \DateTime();
 +    }
  }
+```
+
+<br>
+
+## OrderByKeyToClassConstRector
+
+Replace OrderBy Attribute ASC/DESC with class constant from Criteria
+
+- class: [`Rector\Doctrine\CodeQuality\Rector\Property\OrderByKeyToClassConstRector`](../rules/CodeQuality/Rector/Property/OrderByKeyToClassConstRector.php)
+
+```diff
+ use Doctrine\ORM\Mapping as ORM;
+
+ class ReplaceOrderByAscWithClassConstant
+ {
+-    #[ORM\OrderBy(['createdAt' => 'ASC'])]
++    #[ORM\OrderBy(['createdAt' => \Doctrine\Common\Collections\Criteria::ASC])]
+     protected \DateTimeInterface $messages;
+ }
+ ?>
 ```
 
 <br>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,6 +9,7 @@
   <testsuites>
     <testsuite name="main">
       <directory>tests</directory>
+      <directory>rules-tests</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/rules-tests/CodeQuality/Rector/Property/OrderByKeyToClassConstRector/Fixture/replace_order_by_asc_lower_with_class_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/OrderByKeyToClassConstRector/Fixture/replace_order_by_asc_lower_with_class_constant.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\OrderByKeyToClassConstRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class ReplaceOrderByAscWithClassConstant
+{
+    #[ORM\OrderBy(['createdAt' => 'asc'])]
+    protected \DateTimeInterface $messages;
+}
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\OrderByKeyToClassConstRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class ReplaceOrderByAscWithClassConstant
+{
+    #[ORM\OrderBy(['createdAt' => \Doctrine\Common\Collections\Criteria::ASC])]
+    protected \DateTimeInterface $messages;
+}
+?>

--- a/rules-tests/CodeQuality/Rector/Property/OrderByKeyToClassConstRector/Fixture/replace_order_by_asc_with_class_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/OrderByKeyToClassConstRector/Fixture/replace_order_by_asc_with_class_constant.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\OrderByKeyToClassConstRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class ReplaceOrderByAscWithClassConstant
+{
+    #[ORM\OrderBy(['createdAt' => 'ASC'])]
+    protected \DateTimeInterface $messages;
+}
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\OrderByKeyToClassConstRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class ReplaceOrderByAscWithClassConstant
+{
+    #[ORM\OrderBy(['createdAt' => \Doctrine\Common\Collections\Criteria::ASC])]
+    protected \DateTimeInterface $messages;
+}
+?>

--- a/rules-tests/CodeQuality/Rector/Property/OrderByKeyToClassConstRector/Fixture/replace_order_by_desc_with_class_constant.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/OrderByKeyToClassConstRector/Fixture/replace_order_by_desc_with_class_constant.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\OrderByKeyToClassConstRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class ReplaceOrderByAscWithClassConstant
+{
+    #[ORM\OrderBy(['createdAt' => 'desc'])]
+    protected \DateTimeInterface $messages;
+}
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\OrderByKeyToClassConstRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class ReplaceOrderByAscWithClassConstant
+{
+    #[ORM\OrderBy(['createdAt' => \Doctrine\Common\Collections\Criteria::DESC])]
+    protected \DateTimeInterface $messages;
+}
+?>

--- a/rules-tests/CodeQuality/Rector/Property/OrderByKeyToClassConstRector/Fixture/skip_already_using_const.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/OrderByKeyToClassConstRector/Fixture/skip_already_using_const.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\OrderByKeyToClassConstRector\Fixture;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\Mapping as ORM;
+
+class SkipAlreadyUsingConst
+{
+    #[ORM\OrderBy(['createdAt' => Criteria::ASC])]
+    protected \DateTimeInterface $messages;
+}
+?>

--- a/rules-tests/CodeQuality/Rector/Property/OrderByKeyToClassConstRector/OrderByKeyToClassConstRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Property/OrderByKeyToClassConstRector/OrderByKeyToClassConstRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\OrderByKeyToClassConstRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class OrderByKeyToClassConstRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_set.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Property/OrderByKeyToClassConstRector/config/configured_set.php
+++ b/rules-tests/CodeQuality/Rector/Property/OrderByKeyToClassConstRector/config/configured_set.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\CodeQuality\Rector\Property\OrderByKeyToClassConstRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(OrderByKeyToClassConstRector::class);
+};

--- a/rules/CodeQuality/Rector/Property/OrderByKeyToClassConstRector.php
+++ b/rules/CodeQuality/Rector/Property/OrderByKeyToClassConstRector.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\CodeQuality\Rector\Property;
+
+use Doctrine\Common\Collections\Criteria;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Property;
+use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Doctrine\Tests\CodeQuality\Rector\Property\OrderByKeyToClassConstRector\OrderByKeyToClassConstRectorTest
+ */
+final class OrderByKeyToClassConstRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace OrderBy Attribute ASC/DESC with class constant from Criteria',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Doctrine\ORM\Mapping as ORM;
+
+class ReplaceOrderByAscWithClassConstant
+{
+    #[ORM\OrderBy(['createdAt' => 'ASC'])]
+    protected \DateTimeInterface $messages;
+}
+?>
+CODE_SAMPLE
+
+                    ,
+                    <<<'CODE_SAMPLE'
+use Doctrine\ORM\Mapping as ORM;
+
+class ReplaceOrderByAscWithClassConstant
+{
+    #[ORM\OrderBy(['createdAt' => \Doctrine\Common\Collections\Criteria::ASC])]
+    protected \DateTimeInterface $messages;
+}
+?>
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Property::class];
+    }
+
+    /**
+     * @param Property $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $nodeAttribute = null;
+        foreach ($node->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if ($attr->name->toString() === 'Doctrine\ORM\Mapping\OrderBy') {
+                    $nodeAttribute = $attr;
+                    break 2;
+                }
+            }
+        }
+        // If Attribute is not OrderBy, return null
+        if (null === $nodeAttribute) {
+            return null;
+        }
+
+        if (!isset($nodeAttribute->args[0])) {
+            return null;
+        }
+
+        if (!$nodeAttribute->args[0]->value instanceof Array_) {
+            return null;
+        }
+
+        if (!isset($nodeAttribute->args[0]->value->items[0])) {
+            return null;
+        }
+
+        if (!$nodeAttribute->args[0]->value->items[0] instanceof Node\Expr\ArrayItem) {
+            return null;
+        }
+
+        if (!$nodeAttribute->args[0]->value->items[0]->value instanceof String_) {
+            return null;
+        }
+
+        // If Attribute value from key is not `ASC` or `DESC`, return null
+        if (!in_array($nodeAttribute->args[0]->value->items[0]->value->value, ['ASC', 'asc', 'DESC', 'desc'])) {
+            return null;
+        }
+
+        $upper = strtoupper($nodeAttribute->args[0]->value->items[0]->value->value);
+        $nodeAttribute->args[0]->value->items[0]->value = $this->nodeFactory->createClassConstFetch(
+            Criteria::class,
+            $upper
+        );
+
+        return $node;
+    }
+}


### PR DESCRIPTION
This will make sure to use constants.

```diff
use Doctrine\Common\Collections\Criteria;
use Doctrine\ORM\Mapping as ORM;

class ReplaceOrderByAscWithClassConstant
{
-    #[ORM\OrderBy(['createdAt' => 'ASC'])]
+    #[ORM\OrderBy(['createdAt' => Criteria::ASC])]
    protected \DateTimeInterface $messages;
}
?>

```