### PR TITLE
Revert ::class addition on Doctrine string classname

### DIFF
--- a/src/NodeFactory/ArrayCollectionAssignFactory.php
+++ b/src/NodeFactory/ArrayCollectionAssignFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\NodeFactory;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name\FullyQualified;
@@ -21,7 +20,7 @@ final class ArrayCollectionAssignFactory
     public function createFromPropertyName(string $toManyPropertyName): Expression
     {
         $propertyFetch = $this->nodeFactory->createPropertyFetch('this', $toManyPropertyName);
-        $new = new New_(new FullyQualified(ArrayCollection::class));
+        $new = new New_(new FullyQualified('Doctrine\Common\Collections\ArrayCollection'));
 
         $assign = new Assign($propertyFetch, $new);
 

--- a/src/NodeManipulator/ToOneRelationPropertyTypeResolver.php
+++ b/src/NodeManipulator/ToOneRelationPropertyTypeResolver.php
@@ -122,7 +122,7 @@ final class ToOneRelationPropertyTypeResolver
         DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode
     ): Type {
         $joinDoctrineAnnotationTagValueNode = $phpDocInfo->findOneByAnnotationClass(
-            JoinColumn::class
+            'Doctrine\ORM\Mapping\JoinColumn'
         );
 
         return $this->processToOneRelation(

--- a/src/PhpDocParser/DoctrineDocBlockResolver.php
+++ b/src/PhpDocParser/DoctrineDocBlockResolver.php
@@ -19,6 +19,6 @@ final class DoctrineDocBlockResolver
     public function isDoctrineEntityClass(Class_ $class): bool
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($class);
-        return $phpDocInfo->hasByAnnotationClasses([Entity::class, Embeddable::class]);
+        return $phpDocInfo->hasByAnnotationClasses(['Doctrine\ORM\Mapping\Entity', 'Doctrine\ORM\Mapping\Embeddable']);
     }
 }

--- a/src/TypeAnalyzer/CollectionTypeFactory.php
+++ b/src/TypeAnalyzer/CollectionTypeFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\TypeAnalyzer;
 
-use Doctrine\Common\Collections\Collection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IntegerType;
@@ -26,6 +25,6 @@ final class CollectionTypeFactory
     {
         $genericTypes = [new IntegerType(), $fullyQualifiedObjectType];
 
-        return new GenericObjectType(Collection::class, $genericTypes);
+        return new GenericObjectType('Doctrine\Common\Collections\Collection', $genericTypes);
     }
 }

--- a/src/TypeAnalyzer/CollectionTypeResolver.php
+++ b/src/TypeAnalyzer/CollectionTypeResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\TypeAnalyzer;
 
-use Doctrine\ORM\Mapping\OneToMany;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
@@ -52,7 +51,7 @@ final class CollectionTypeResolver
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
-        $doctrineAnnotationTagValueNode = $phpDocInfo->getByAnnotationClass(OneToMany::class);
+        $doctrineAnnotationTagValueNode = $phpDocInfo->getByAnnotationClass('Doctrine\ORM\Mapping\OneToMany');
         if (! $doctrineAnnotationTagValueNode instanceof DoctrineAnnotationTagValueNode) {
             return null;
         }

--- a/src/TypeAnalyzer/CollectionVarTagValueNodeResolver.php
+++ b/src/TypeAnalyzer/CollectionVarTagValueNodeResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\TypeAnalyzer;
 
-use Doctrine\ORM\Mapping\OneToMany;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -19,7 +18,7 @@ final class CollectionVarTagValueNodeResolver
     public function resolve(Property $property): ?VarTagValueNode
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
-        if (! $phpDocInfo->hasByAnnotationClass(OneToMany::class)) {
+        if (! $phpDocInfo->hasByAnnotationClass('Doctrine\ORM\Mapping\OneToMany')) {
             return null;
         }
 

--- a/src/TypeAnalyzer/DoctrineCollectionTypeAnalyzer.php
+++ b/src/TypeAnalyzer/DoctrineCollectionTypeAnalyzer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\TypeAnalyzer;
 
-use Doctrine\Common\Collections\Collection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
@@ -50,6 +49,6 @@ final class DoctrineCollectionTypeAnalyzer
 
         $className = $type instanceof ShortenedObjectType ? $type->getFullyQualifiedName() : $type->getClassName();
 
-        return $className === Collection::class;
+        return $className === 'Doctrine\Common\Collections\Collection';
     }
 }


### PR DESCRIPTION
@TomasVotruba this is changed by rectify on PR:

- https://github.com/rectorphp/rector-doctrine/pull/221#pullrequestreview-1600786712

seems due to new laravel container that `$isBound` no longer valid way to verify service registered once. The `singleton()` seems already cover it :)