### PR TITLE
[EventSubscriberInterfaceToAttributeRector] Add rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "symplify/easy-ci": "^11.2",
         "tomasvotruba/unused-public": "^0.3",
         "tomasvotruba/type-coverage": "^0.2",
-        "tomasvotruba/class-leak": "^0.1"
+        "tomasvotruba/class-leak": "^0.1",
+        "doctrine/doctrine-bundle": "^2.10"
     },
     "autoload": {
         "psr-4": {

--- a/config/sets/doctrine-bundle-210.php
+++ b/config/sets/doctrine-bundle-210.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(EventSubscriberInterfaceToAttributeRector::class);
+};

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 14 Rules Overview
+# 15 Rules Overview
 
 ## ChangeCompositeExpressionAddMultipleWithWithRector
 
@@ -42,6 +42,46 @@ Change default value types to match Doctrine annotation type
       */
 -    private $isOld = '0';
 +    private $isOld = false;
+ }
+```
+
+<br>
+
+## EventSubscriberInterfaceToAttributeRector
+
+Replace EventSubscriberInterface with AsDoctrineListener attribute(s)
+
+- class: [`Rector\Doctrine\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector`](../rules/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector.php)
+
+```diff
++use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+ use Doctrine\ORM\Event\PrePersistEventArgs;
+ use Doctrine\ORM\Event\PostUpdateEventArgs;
+-use Doctrine\Common\EventSubscriber;
+ use Doctrine\ORM\Events;
+
+-class MyEventSubscriber implements EventSubscriber
++#[AsDoctrineListener(event: Events::postUpdate)]
++#[AsDoctrineListener(event: Events::prePersist)]
++class MyEventSubscriber
+ {
+-    public function getSubscribedEvents()
+-    {
+-        return array(
+-            Events::postUpdate,
+-            Events::prePersist,
+-        );
+-    }
+-
+     public function postUpdate(PostUpdateEventArgs $args)
+     {
+         // ...
+     }
+
+     public function prePersist(PrePersistEventArgs $args)
+     {
+         // ...
+     }
  }
 ```
 

--- a/rules-tests/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector/EventSubscriberInterfaceToAttributeRectorTest.php
+++ b/rules-tests/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector/EventSubscriberInterfaceToAttributeRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EventSubscriberInterfaceToAttributeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector/Fixture/fixture.php.inc
+++ b/rules-tests/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector/Fixture/fixture.php.inc
@@ -1,0 +1,82 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector\Fixture;
+
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Events;
+
+class MyEventSubscriber implements EventSubscriber
+{
+    public function getSubscribedEvents()
+    {
+        return array(
+            Events::postUpdate,
+            Events::prePersist,
+            'postPersist',
+            Events::postFlush,
+        );
+    }
+
+    public function postUpdate(PostUpdateEventArgs $args)
+    {
+        // ...
+    }
+
+    public function prePersist(PrePersistEventArgs $args)
+    {
+        // ...
+    }
+
+    public function postPersist(PostPersistEventArgs $args)
+    {
+        // ...
+    }
+
+    public function postFlush(PostFlushEventArgs $args): void
+    {
+        // ...
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector\Fixture;
+
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Events;
+
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener(event: Events::postUpdate)]
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener(event: Events::prePersist)]
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener(event: 'postPersist')]
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener(event: Events::postFlush)]
+class MyEventSubscriber
+{
+    public function postUpdate(PostUpdateEventArgs $args)
+    {
+        // ...
+    }
+    public function prePersist(PrePersistEventArgs $args)
+    {
+        // ...
+    }
+    public function postPersist(PostPersistEventArgs $args)
+    {
+        // ...
+    }
+    public function postFlush(PostFlushEventArgs $args): void
+    {
+        // ...
+    }
+}
+
+?>

--- a/rules-tests/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector/Fixture/skip_asdoctrinelistener.php.inc
+++ b/rules-tests/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector/Fixture/skip_asdoctrinelistener.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector\Fixture;
+
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Events;
+
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener(event: Events::postUpdate)]
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener(event: Events::prePersist)]
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener(event: 'postPersist')]
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener(event: Events::postFlush)]
+class MyEventSubscriber
+{
+    public function postUpdate(PostUpdateEventArgs $args)
+    {
+        // ...
+    }
+    public function prePersist(PrePersistEventArgs $args)
+    {
+        // ...
+    }
+    public function postPersist(PostPersistEventArgs $args)
+    {
+        // ...
+    }
+    public function postFlush(PostFlushEventArgs $args): void
+    {
+        // ...
+    }
+}
+
+?>

--- a/rules-tests/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(EventSubscriberInterfaceToAttributeRector::class);
+};

--- a/rules/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector.php
+++ b/rules/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Bundle210\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://github.com/doctrine/DoctrineBundle/pull/1664
+ *
+ * @see \Rector\Doctrine\Tests\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector\EventSubscriberInterfaceToAttributeRectorTest
+ */
+final class EventSubscriberInterfaceToAttributeRector extends AbstractRector implements MinPhpVersionInterface
+{
+    private Class_ $subscriberClass;
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ATTRIBUTES;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace EventSubscriberInterface with AsDoctrineListener attribute(s)',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Events;
+
+class MyEventSubscriber implements EventSubscriber
+{
+    public function getSubscribedEvents()
+    {
+        return array(
+            Events::postUpdate,
+            Events::prePersist,
+        );
+    }
+
+    public function postUpdate(PostUpdateEventArgs $args)
+    {
+        // ...
+    }
+
+    public function prePersist(PrePersistEventArgs $args)
+    {
+        // ...
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\Events;
+
+#[AsDoctrineListener(event: Events::postUpdate)]
+#[AsDoctrineListener(event: Events::prePersist)]
+class MyEventSubscriber
+{
+    public function postUpdate(PostUpdateEventArgs $args)
+    {
+        // ...
+    }
+
+    public function prePersist(PrePersistEventArgs $args)
+    {
+        // ...
+    }
+}
+CODE_SAMPLE
+                ),
+
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->hasImplements($node, 'Doctrine\Common\EventSubscriber')) {
+            return null;
+        }
+
+        $this->subscriberClass = $node;
+
+        $getSubscribedEventsClassMethod = $node->getMethod('getSubscribedEvents');
+        if (! $getSubscribedEventsClassMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        $stmts = (array) $getSubscribedEventsClassMethod->stmts;
+        if ($stmts === []) {
+            return null;
+        }
+
+        if (
+            ($stmts[0] instanceof Return_) &&
+            $stmts[0]->expr instanceof Array_
+        ) {
+            $this->handleArray($stmts);
+        }
+
+        $this->removeImplements($node, ['Doctrine\Common\EventSubscriber']);
+        unset($node->stmts[$getSubscribedEventsClassMethod->getAttribute(AttributeKey::STMT_KEY)]);
+
+        return $node;
+    }
+
+    /**
+     * @param array<int, Node\Stmt> $expressions
+     */
+    private function handleArray(array $expressions): void
+    {
+        foreach ($expressions as $expression) {
+            if (! $expression instanceof Return_ ||
+                 ! $expression->expr instanceof Array_
+            ) {
+                continue;
+            }
+
+            $arguments = [];
+
+            $arguments = $this->parseArguments($expression->expr);
+            $this->addAttribute($arguments);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseArguments(Array_ $array): array
+    {
+        foreach ($array->items as $item) {
+            if (
+                ! $item instanceof ArrayItem
+            ) {
+                continue;
+            }
+
+            $arguments[] = $item->value;
+        }
+
+        return $arguments ?? [];
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    private function addAttribute(array $arguments): void
+    {
+        foreach ($arguments as $argument) {
+            $this->subscriberClass->attrGroups[] = new AttributeGroup([new Attribute(
+                new FullyQualified('Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener'),
+                [new Arg($argument, name: new Identifier('event'))]
+            )]);
+        }
+    }
+
+    private function hasImplements(Class_ $class, string $interfaceFQN): bool
+    {
+        foreach ($class->implements as $implement) {
+            if ($this->nodeNameResolver->isName($implement, $interfaceFQN)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function removeImplements(Class_ $class, array $interfaceFQNS): void
+    {
+        foreach ($class->implements as $key => $implement) {
+            if (! $this->nodeNameResolver->isNames($implement, $interfaceFQNS)) {
+                continue;
+            }
+
+            unset($class->implements[$key]);
+        }
+    }
+}

--- a/rules/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector.php
+++ b/rules/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Identifier;
@@ -159,7 +160,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<Expr>
      */
     private function parseArguments(Array_ $array): array
     {
@@ -177,14 +178,14 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, mixed> $arguments
+     * @param array<Expr> $arguments
      */
     private function addAttribute(array $arguments): void
     {
         foreach ($arguments as $argument) {
             $this->subscriberClass->attrGroups[] = new AttributeGroup([new Attribute(
                 new FullyQualified('Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener'),
-                [new Arg($argument, name: new Identifier('event'))]
+                [new Arg($argument, false, false, [], new Identifier('event'))]
             )]);
         }
     }
@@ -200,6 +201,9 @@ CODE_SAMPLE
         return false;
     }
 
+    /**
+     * @param array<string> $interfaceFQNS
+     */
     private function removeImplements(Class_ $class, array $interfaceFQNS): void
     {
         foreach ($class->implements as $key => $implement) {

--- a/src/Set/DoctrineSetList.php
+++ b/src/Set/DoctrineSetList.php
@@ -77,6 +77,11 @@ final class DoctrineSetList implements SetListInterface
     /**
      * @var string
      */
+    public const DOCTRINE_BUNDLE_210 = __DIR__ . '/../../config/sets/doctrine-bundle-210.php';
+
+    /**
+     * @var string
+     */
     public const ANNOTATIONS_TO_ATTRIBUTES = __DIR__ . '/../../config/sets/doctrine-annotations-to-attributes.php';
 
     /**

--- a/tests/Set/DoctrineBUNDLE210Set/DoctrineBUNDLE210SetTest.php
+++ b/tests/Set/DoctrineBUNDLE210Set/DoctrineBUNDLE210SetTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Set\DoctrineBUNDLE210Set;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DoctrineBUNDLE210SetTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_set.php';
+    }
+}

--- a/tests/Set/DoctrineBUNDLE210Set/Fixture/eventsubscriber_to_attribute.php.inc
+++ b/tests/Set/DoctrineBUNDLE210Set/Fixture/eventsubscriber_to_attribute.php.inc
@@ -1,0 +1,82 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector\Fixture;
+
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Events;
+
+class MyEventSubscriber implements EventSubscriber
+{
+    public function getSubscribedEvents()
+    {
+        return array(
+            Events::postUpdate,
+            Events::prePersist,
+            'postPersist',
+            Events::postFlush,
+        );
+    }
+
+    public function postUpdate(PostUpdateEventArgs $args)
+    {
+        // ...
+    }
+
+    public function prePersist(PrePersistEventArgs $args)
+    {
+        // ...
+    }
+
+    public function postPersist(PostPersistEventArgs $args)
+    {
+        // ...
+    }
+
+    public function postFlush(PostFlushEventArgs $args): void
+    {
+        // ...
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Bundle210\Rector\Class_\EventSubscriberInterfaceToAttributeRector\Fixture;
+
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Events;
+
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener(event: Events::postUpdate)]
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener(event: Events::prePersist)]
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener(event: 'postPersist')]
+#[\Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener(event: Events::postFlush)]
+class MyEventSubscriber
+{
+    public function postUpdate(PostUpdateEventArgs $args)
+    {
+        // ...
+    }
+    public function prePersist(PrePersistEventArgs $args)
+    {
+        // ...
+    }
+    public function postPersist(PostPersistEventArgs $args)
+    {
+        // ...
+    }
+    public function postFlush(PostFlushEventArgs $args): void
+    {
+        // ...
+    }
+}
+
+?>

--- a/tests/Set/DoctrineBUNDLE210Set/config/configured_set.php
+++ b/tests/Set/DoctrineBUNDLE210Set/config/configured_set.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+use Rector\Doctrine\Set\DoctrineSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([DoctrineSetList::DOCTRINE_BUNDLE_210]);
+};


### PR DESCRIPTION
Add a rule to fix `EventSubscriberInterface` deprecation and convert it to `#[AsDoctrineListener]` (https://github.com/doctrine/DoctrineBundle/pull/1664) 

This is my first rector rule and contribution in this project, so this PR will probably need some changes.