### PR TITLE
Update phpstan.neon for PHP83

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -32,7 +32,7 @@ parameters:
         - '#Parameter \#1 \$tag of method Rector\\BetterPhpDocParser\\PhpDocParser\\ClassAnnotationMatcher\:\:resolveTagFullyQualifiedName\(\) expects string, string\|null given#'
 
         -
-            message: '#Parameter \#1 \$phpVersion of method Rector\\Config\\RectorConfig\:\:phpVersion\(\) expects 50200\|50300\|50400\|50500\|50600\|70000\|70100\|70200\|70300\|70400\|80000\|80100\|80200\|100000, \d+ given#'
+            message: '#Parameter \#1 \$phpVersion of method Rector\\Config\\RectorConfig\:\:phpVersion\(\) expects 50200\|50300\|50400\|50500\|50600\|70000\|70100\|70200\|70300\|70400\|80000\|80100\|80200\|80300\|100000, \d+ given#'
             paths:
                 - tests/Set/DoctrineORM29Set/config/configured_set.php
 


### PR DESCRIPTION
Looking to introduce as part of [a PR to make PHP83 rules available](https://github.com/rectorphp/rector-src/pull/5170) but this repo's PHPStan config required updating to work.