### PR TITLE
Update Collection<T> type-hint to Collection<TKey, T>

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -354,7 +354,7 @@ Complete `@var` annotations or types based on @ORM\*toMany annotations or attrib
  {
      /**
       * @ORM\OneToMany(targetEntity="App\Product")
-+     * @var \Doctrine\Common\Collections\Collection<\App\Product>
++     * @var \Doctrine\Common\Collections\Collection<int, \App\Product>
       */
 -    private $products;
 +    private \Doctrine\Common\Collections\Collection $products;

--- a/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromToManyRelationTypeRector/Fixture/doctrine_attribute_relation_to_many.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromToManyRelationTypeRector/Fixture/doctrine_attribute_relation_to_many.php.inc
@@ -34,13 +34,13 @@ use Doctrine\ORM\Mapping as ORM;
 class DoctrineRelationToMany
 {
     /**
-     * @var \Doctrine\Common\Collections\Collection<\App\Product>
+     * @var \Doctrine\Common\Collections\Collection<int, \App\Product>
      */
     #[ORM\OneToMany(targetEntity:"App\Product")]
     private \Doctrine\Common\Collections\Collection $products;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<\App\Car>
+     * @var \Doctrine\Common\Collections\Collection<int, \App\Car>
      */
     #[ORM\ManyToMany(targetEntity:"App\Car")]
     private \Doctrine\Common\Collections\Collection $cars;

--- a/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromToManyRelationTypeRector/Fixture/doctrine_relation_to_many.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromToManyRelationTypeRector/Fixture/doctrine_relation_to_many.php.inc
@@ -37,13 +37,13 @@ class DoctrineRelationToMany
 {
     /**
      * @ORM\OneToMany(targetEntity="App\Product")
-     * @var \Doctrine\Common\Collections\Collection<\App\Product>
+     * @var \Doctrine\Common\Collections\Collection<int, \App\Product>
      */
     private \Doctrine\Common\Collections\Collection $products;
 
     /**
      * @ORM\ManyToMany(targetEntity="App\Car")
-     * @var \Doctrine\Common\Collections\Collection<\App\Car>
+     * @var \Doctrine\Common\Collections\Collection<int, \App\Car>
      */
     private \Doctrine\Common\Collections\Collection $cars;
 

--- a/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromToManyRelationTypeRector/Fixture/to_many_intersection.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromToManyRelationTypeRector/Fixture/to_many_intersection.php.inc
@@ -35,7 +35,7 @@ class ToManyIntersection
 {
     /**
      * @ORM\OneToMany(targetEntity="Pehapkari\Training\Entity\TrainingTerm", mappedBy="training")
-     * @var \Doctrine\Common\Collections\Collection<\Pehapkari\Training\Entity\TrainingTerm>
+     * @var \Doctrine\Common\Collections\Collection<int, \Pehapkari\Training\Entity\TrainingTerm>
      */
     private \Doctrine\Common\Collections\Collection $training;
 }

--- a/rules/CodeQuality/Rector/Property/TypedPropertyFromToManyRelationTypeRector.php
+++ b/rules/CodeQuality/Rector/Property/TypedPropertyFromToManyRelationTypeRector.php
@@ -63,7 +63,7 @@ class SimpleColumn
 {
     /**
      * @ORM\OneToMany(targetEntity="App\Product")
-     * @var \Doctrine\Common\Collections\Collection<\App\Product>
+     * @var \Doctrine\Common\Collections\Collection<int, \App\Product>
      */
     private \Doctrine\Common\Collections\Collection $products;
 }

--- a/src/NodeManipulator/ToManyRelationPropertyTypeResolver.php
+++ b/src/NodeManipulator/ToManyRelationPropertyTypeResolver.php
@@ -6,7 +6,6 @@ namespace Rector\Doctrine\NodeManipulator;
 
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt\Property;
-use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
@@ -15,6 +14,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Doctrine\NodeAnalyzer\AttributeFinder;
 use Rector\Doctrine\PhpDoc\ShortClassExpander;
+use Rector\Doctrine\TypeAnalyzer\CollectionTypeFactory;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
 final class ToManyRelationPropertyTypeResolver
@@ -37,6 +37,7 @@ final class ToManyRelationPropertyTypeResolver
         private readonly ShortClassExpander $shortClassExpander,
         private readonly AttributeFinder $attributeFinder,
         private readonly ValueResolver $valueResolver,
+        private readonly CollectionTypeFactory $collectionTypeFactory,
     ) {
     }
 
@@ -97,6 +98,6 @@ final class ToManyRelationPropertyTypeResolver
         $entityFullyQualifiedClass = $this->shortClassExpander->resolveFqnTargetEntity($targetEntity, $property);
         $fullyQualifiedObjectType = new FullyQualifiedObjectType($entityFullyQualifiedClass);
 
-        return new GenericObjectType(self::COLLECTION_TYPE, [$fullyQualifiedObjectType]);
+        return $this->collectionTypeFactory->createGenericObjectType($fullyQualifiedObjectType);
     }
 }

--- a/src/TypeAnalyzer/CollectionTypeFactory.php
+++ b/src/TypeAnalyzer/CollectionTypeFactory.php
@@ -21,7 +21,7 @@ final class CollectionTypeFactory
         return new UnionType([$genericObjectType, $arrayType]);
     }
 
-    private function createGenericObjectType(FullyQualifiedObjectType $fullyQualifiedObjectType): GenericObjectType
+    public function createGenericObjectType(FullyQualifiedObjectType $fullyQualifiedObjectType): GenericObjectType
     {
         $genericTypes = [new IntegerType(), $fullyQualifiedObjectType];
 


### PR DESCRIPTION
Doctrine Collection takes two arguments: key type and element type. For `TypedPropertyFromToManyRelationTypeRector` key type was missing. After changes it should work similarly to `ImproveDoctrineCollectionDocTypeInEntityRector`
