### PR TITLE
Add fixture for auto imported curly list

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -40,7 +40,9 @@ parameters:
 
         # laravel config
         -
-            path: config/yaml-to-annotations.php
+            paths:
+                - config/yaml-to-annotations.php
+                - rules-tests/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector/config/import_names.php
             message: '#Do not use chained method calls\. Put each on separated lines#'
 
         # config example
@@ -54,3 +56,7 @@ parameters:
             paths:
                 - src/NodeManipulator/ColumnPropertyTypeResolver.php
                 - src/NodeManipulator/NullabilityColumnPropertyTypeResolver.php
+
+        -
+            message: '#Method ".+\(\)" returns bool type, so the name should start with is/has/was\.\.\.#'
+            path: rules/CodeQuality/AnnotationTransformer/YamlToAnnotationTransformer.php

--- a/rules-tests/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector/ImportNamesFixture/imported_unique_constraints.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector/ImportNamesFixture/imported_unique_constraints.php.inc
@@ -14,7 +14,7 @@ namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\YamlToAnnotationsDoctr
 
 use Doctrine\ORM\Mapping\Table;
 /**
- * @Table(name="some_table", uniqueConstraints={@\Doctrine\ORM\Mapping\UniqueConstraint(name="key_name",columns={"key_id", "next_key_id"})})
+ * @Table(name="some_table", uniqueConstraints={@\Doctrine\ORM\Mapping\UniqueConstraint(name="key_name", columns={"key_id", "next_key_id"})})
  */
 final class ImprotedUniqueConstraints
 {

--- a/rules-tests/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector/ImportNamesFixture/imported_unique_constraints.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector/ImportNamesFixture/imported_unique_constraints.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\YamlToAnnotationsDoctrineMappingRector\ImportNamesFixture;
+
+final class ImprotedUniqueConstraints
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\YamlToAnnotationsDoctrineMappingRector\ImportNamesFixture;
+
+use Doctrine\ORM\Mapping\Table;
+/**
+ * @Table(name="some_table", uniqueConstraints={@\Doctrine\ORM\Mapping\UniqueConstraint(name="key_name",columns={"key_id", "next_key_id"})})
+ */
+final class ImprotedUniqueConstraints
+{
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector/ImportNamesYamlToAnnotationsDoctrineMappingRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector/ImportNamesYamlToAnnotationsDoctrineMappingRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\YamlToAnnotationsDoctrineMappingRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ImportNamesYamlToAnnotationsDoctrineMappingRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/ImportNamesFixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/import_names.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector/config/import_names.php
+++ b/rules-tests/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector/config/import_names.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\CodeQuality\Rector\Class_\YamlToAnnotationsDoctrineMappingRector;
+
+return RectorConfig::configure()
+    ->withImportNames()
+    ->withConfiguredRule(YamlToAnnotationsDoctrineMappingRector::class, [__DIR__ . '/yaml_mapping']);

--- a/rules-tests/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector/config/yaml_mapping/import_names_unique_constraints.yml
+++ b/rules-tests/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector/config/yaml_mapping/import_names_unique_constraints.yml
@@ -1,0 +1,5 @@
+Rector\Doctrine\Tests\CodeQuality\Rector\Class_\YamlToAnnotationsDoctrineMappingRector\ImportNamesFixture\ImprotedUniqueConstraints:
+    table: "some_table"
+    uniqueConstraints:
+        key_name:
+            columns: [key_id, next_key_id]

--- a/rules/CodeQuality/AnnotationTransformer/ClassAnnotationTransformer/TableClassAnnotationTransformer.php
+++ b/rules/CodeQuality/AnnotationTransformer/ClassAnnotationTransformer/TableClassAnnotationTransformer.php
@@ -24,11 +24,7 @@ final class TableClassAnnotationTransformer implements ClassAnnotationTransforme
     /**
      * @var string
      */
-<<<<<<< HEAD
-    private const UNIQUE_CONSTRAINTS_CLASS = 'Doctrine\ORM\Mapping\UniqueConstraint';
-=======
     private const UNIQUE_CONSTRAINT_CLASS = 'Doctrine\ORM\Mapping\UniqueConstraint';
->>>>>>> c6d0a51 (misc)
 
     public function transform(EntityMapping $entityMapping, PhpDocInfo $classPhpDocInfo): void
     {
@@ -58,11 +54,7 @@ final class TableClassAnnotationTransformer implements ClassAnnotationTransforme
 
                 $uniqueConstraintDoctrineAnnotationTagValueNodes[] = new ArrayItemNode(
                     new DoctrineAnnotationTagValueNode(
-<<<<<<< HEAD
-                        new IdentifierTypeNode('@\\' . self::UNIQUE_CONSTRAINTS_CLASS),
-=======
-                        new IdentifierTypeNode('@\\' . self::UNIQUE_CONSTRAINT_CLASS . ''),
->>>>>>> c6d0a51 (misc)
+                        new IdentifierTypeNode('@\\' . self::UNIQUE_CONSTRAINT_CLASS),
                         null,
                         [
                             new ArrayItemNode(new StringNode($name), 'name'),

--- a/rules/CodeQuality/AnnotationTransformer/ClassAnnotationTransformer/TableClassAnnotationTransformer.php
+++ b/rules/CodeQuality/AnnotationTransformer/ClassAnnotationTransformer/TableClassAnnotationTransformer.php
@@ -24,7 +24,11 @@ final class TableClassAnnotationTransformer implements ClassAnnotationTransforme
     /**
      * @var string
      */
+<<<<<<< HEAD
     private const UNIQUE_CONSTRAINTS_CLASS = 'Doctrine\ORM\Mapping\UniqueConstraint';
+=======
+    private const UNIQUE_CONSTRAINT_CLASS = 'Doctrine\ORM\Mapping\UniqueConstraint';
+>>>>>>> c6d0a51 (misc)
 
     public function transform(EntityMapping $entityMapping, PhpDocInfo $classPhpDocInfo): void
     {
@@ -54,7 +58,11 @@ final class TableClassAnnotationTransformer implements ClassAnnotationTransforme
 
                 $uniqueConstraintDoctrineAnnotationTagValueNodes[] = new ArrayItemNode(
                     new DoctrineAnnotationTagValueNode(
+<<<<<<< HEAD
                         new IdentifierTypeNode('@\\' . self::UNIQUE_CONSTRAINTS_CLASS),
+=======
+                        new IdentifierTypeNode('@\\' . self::UNIQUE_CONSTRAINT_CLASS . ''),
+>>>>>>> c6d0a51 (misc)
                         null,
                         [
                             new ArrayItemNode(new StringNode($name), 'name'),

--- a/rules/CodeQuality/Rector/Class_/MoveCurrentDateTimeDefaultInEntityToConstructorRector.php
+++ b/rules/CodeQuality/Rector/Class_/MoveCurrentDateTimeDefaultInEntityToConstructorRector.php
@@ -33,6 +33,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class MoveCurrentDateTimeDefaultInEntityToConstructorRector extends AbstractRector
 {
+    /**
+     * @var string
+     */
+    private const COLUMN_CLASS = 'Doctrine\ORM\Mapping\Column';
+
     private bool $hasChanged = false;
 
     public function __construct(
@@ -125,7 +130,7 @@ CODE_SAMPLE
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
-        $doctrineAnnotationTagValueNode = $phpDocInfo->getByAnnotationClass('Doctrine\ORM\Mapping\Column');
+        $doctrineAnnotationTagValueNode = $phpDocInfo->getByAnnotationClass(self::COLUMN_CLASS);
         if (! $doctrineAnnotationTagValueNode instanceof DoctrineAnnotationTagValueNode) {
             return;
         }

--- a/rules/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector.php
+++ b/rules/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector.php
@@ -96,7 +96,11 @@ CODE_SAMPLE
             return null;
         }
 
-        $this->yamlToAnnotationTransformer->transform($node, $entityMapping);
+        $hasChanged = $this->yamlToAnnotationTransformer->transform($node, $entityMapping);
+
+        if (! $hasChanged) {
+            return null;
+        }
 
         return $node;
     }


### PR DESCRIPTION
The one-liner to reproduce failng test case locally:

```bash
vendor/bin/phpunit rules-tests/CodeQuality/Rector/Class_/YamlToAnnotationsDoctrineMappingRector/ImportNamesYamlToAnnotationsDoctrineMappingRectorTest.php
```

While debugging I got into `\Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\PlainValueParser`, so I assume it will be somewhere in there. Possibly related to `ArrayItemNode` and `\Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNode`