### PR TITLE
Fix new constant name for Order

### DIFF
--- a/config/sets/doctrine-collection-22.php
+++ b/config/sets/doctrine-collection-22.php
@@ -12,13 +12,13 @@ return static function (RectorConfig $rectorConfig): void {
             'Doctrine\\Common\\Collections\\Criteria',
             'ASC',
             'Doctrine\\Common\\Collections\\Order',
-            'ASC'
+            'Ascending'
         ),
         new RenameClassAndConstFetch(
             'Doctrine\\Common\\Collections\\Criteria',
             'DESC',
             'Doctrine\\Common\\Collections\\Order',
-            'DESC'
+            'Descending'
         ),
     ]);
 };

--- a/tests/Set/DoctrineCOLLECTION22Set/Fixture/criteria_to_order.php.inc
+++ b/tests/Set/DoctrineCOLLECTION22Set/Fixture/criteria_to_order.php.inc
@@ -11,4 +11,4 @@ $criteria->orderBy(['asc' => Criteria::ASC, 'desc' => Criteria::DESC]);
 use Doctrine\Common\Collections\Criteria;
 
 $criteria = new Criteria();
-$criteria->orderBy(['asc' => \Doctrine\Common\Collections\Order::ASC, 'desc' => \Doctrine\Common\Collections\Order::DESC]);
+$criteria->orderBy(['asc' => \Doctrine\Common\Collections\Order::Ascending, 'desc' => \Doctrine\Common\Collections\Order::Descending]);


### PR DESCRIPTION
Fix the new constant name, which is now 'Ascending' (instead of 'ASC') and 'Descending' (instead of 'DESC').

-----

I'm really sorry: I introduced a mistake here: the correct new constant name is now `Ascending` and `Descending`. 

Really sorry about the noise and this mistake...