### PR TITLE
Transform single joinColumn from yaml to attribute

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector/Fixture/many_to_one_join_column.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector/Fixture/many_to_one_join_column.php.inc
@@ -7,6 +7,8 @@ final class ManyToOneJoinColumn
     public $anotherObject;
 
     public $simpleObject;
+
+    public $objectWithSingleJoinColumnNotation;
 }
 
 ?>
@@ -26,6 +28,10 @@ final class ManyToOneJoinColumn
     #[\Doctrine\ORM\Mapping\JoinColumn(name: 'first_column_name', referencedColumnName: 'some_id')]
     #[\Doctrine\ORM\Mapping\JoinColumn(name: 'second_column_name', referencedColumnName: 'some_id')]
     public $simpleObject;
+
+    #[\Doctrine\ORM\Mapping\ManyToOne(targetEntity: \App\SomeTargetEntity::class)]
+    #[\Doctrine\ORM\Mapping\JoinColumn(name: 'single_column_notation', referencedColumnName: 'some_id')]
+    public $objectWithSingleJoinColumnNotation;
 }
 
 ?>

--- a/rules-tests/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector/config/yaml_mapping/many_to_one_join_column.yaml
+++ b/rules-tests/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector/config/yaml_mapping/many_to_one_join_column.yaml
@@ -13,3 +13,8 @@ Rector\Doctrine\Tests\CodeQuality\Rector\Class_\YamlToAttributeDoctrineMappingRe
                     referencedColumnName: some_id
                 second_column_name:
                     referencedColumnName: some_id
+        objectWithSingleJoinColumnNotation:
+            targetEntity: App\SomeTargetEntity
+            joinColumn:
+                name: single_column_notation
+                referencedColumnName: some_id

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/JoinColumnAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/JoinColumnAttributeTransformer.php
@@ -28,7 +28,7 @@ final readonly class JoinColumnAttributeTransformer implements PropertyAttribute
         }
 
         $singleJoinColumn = $manyToOnePropertyMapping['joinColumn'] ?? null;
-        if ($singleJoinColumn) {
+        if (is_array($singleJoinColumn)) {
             $name = $singleJoinColumn['name'];
             unset($singleJoinColumn['name']);
             $manyToOnePropertyMapping['joinColumns'][$name] = $singleJoinColumn;

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/JoinColumnAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/JoinColumnAttributeTransformer.php
@@ -27,6 +27,13 @@ final readonly class JoinColumnAttributeTransformer implements PropertyAttribute
             return;
         }
 
+        $singleJoinColumn = $manyToOnePropertyMapping['joinColumn'] ?? null;
+        if ($singleJoinColumn) {
+            $name = $singleJoinColumn['name'];
+            unset($singleJoinColumn['name']);
+            $manyToOnePropertyMapping['joinColumns'][$name] = $singleJoinColumn;
+        }
+
         $joinColumns = $manyToOnePropertyMapping['joinColumns'] ?? null;
         if (! is_array($joinColumns)) {
             return;

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/ManyToOneAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/ManyToOneAttributeTransformer.php
@@ -29,7 +29,7 @@ final readonly class ManyToOneAttributeTransformer implements PropertyAttributeT
         }
 
         // handled by another mapper
-        unset($manyToOneMapping['joinColumns']);
+        unset($manyToOneMapping['joinColumn'], $manyToOneMapping['joinColumns']);
 
         // non existing
         unset($manyToOneMapping['nullable']);


### PR DESCRIPTION
Allow using `joinColumn`-notation in `manyToOne` to be correctly transformed into a `JoinColumn` attribute.