### PR TITLE
Transform manyToMany from yaml to attributes

### DIFF
--- a/config/yaml-to-annotations.php
+++ b/config/yaml-to-annotations.php
@@ -14,7 +14,10 @@ use Rector\Doctrine\CodeQuality\AttributeTransformer\PropertyAttributeTransforme
 use Rector\Doctrine\CodeQuality\AttributeTransformer\PropertyAttributeTransformer\IdAttributeTransformer;
 use Rector\Doctrine\CodeQuality\AttributeTransformer\PropertyAttributeTransformer\IdColumnAttributeTransformer;
 use Rector\Doctrine\CodeQuality\AttributeTransformer\PropertyAttributeTransformer\IdGeneratorAttributeTransformer;
+use Rector\Doctrine\CodeQuality\AttributeTransformer\PropertyAttributeTransformer\InverseJoinColumnAttributeTransformer;
 use Rector\Doctrine\CodeQuality\AttributeTransformer\PropertyAttributeTransformer\JoinColumnAttributeTransformer;
+use Rector\Doctrine\CodeQuality\AttributeTransformer\PropertyAttributeTransformer\JoinTableAttributeTransformer;
+use Rector\Doctrine\CodeQuality\AttributeTransformer\PropertyAttributeTransformer\ManyToManyAttributeTransformer;
 use Rector\Doctrine\CodeQuality\AttributeTransformer\PropertyAttributeTransformer\ManyToOneAttributeTransformer;
 use Rector\Doctrine\CodeQuality\AttributeTransformer\PropertyAttributeTransformer\OneToManyAttributeTransformer;
 use Rector\Doctrine\CodeQuality\AttributeTransformer\PropertyAttributeTransformer\OrderByAttributeTransformer;
@@ -40,9 +43,12 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->singleton(IdAttributeTransformer::class);
     $rectorConfig->singleton(IdColumnAttributeTransformer::class);
     $rectorConfig->singleton(IdGeneratorAttributeTransformer::class);
+    $rectorConfig->singleton(ManyToManyAttributeTransformer::class);
     $rectorConfig->singleton(ManyToOneAttributeTransformer::class);
     $rectorConfig->singleton(OneToManyAttributeTransformer::class);
+    $rectorConfig->singleton(JoinTableAttributeTransformer::class);
     $rectorConfig->singleton(JoinColumnAttributeTransformer::class);
+    $rectorConfig->singleton(InverseJoinColumnAttributeTransformer::class);
     $rectorConfig->singleton(OrderByAttributeTransformer::class);
 
     $rectorConfig->when(YamlToAttributeTransformer::class)

--- a/rules-tests/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector/Fixture/many_to_many.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector/Fixture/many_to_many.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\YamlToAttributeDoctrineMappingRector\Fixture;
+
+final class ManyToMany
+{
+    public $myObjects;
+
+    public $theirObjects;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\YamlToAttributeDoctrineMappingRector\Fixture;
+
+#[\Doctrine\ORM\Mapping\Table]
+final class ManyToMany
+{
+    #[\Doctrine\ORM\Mapping\ManyToMany(targetEntity: \App\SomeTargetEntity::class, inversedBy: 'theirObjects')]
+    #[\Doctrine\ORM\Mapping\JoinTable(name: 'owned_objects')]
+    #[\Doctrine\ORM\Mapping\JoinColumn(name: 'owner_id', referencedColumnName: 'some_id', onDelete: 'cascade')]
+    #[\Doctrine\ORM\Mapping\InverseJoinColumn(name: 'object_id', referencedColumnName: 'some_id', onDelete: 'cascade')]
+    public $myObjects;
+
+    #[\Doctrine\ORM\Mapping\ManyToMany(targetEntity: \App\SomeTargetEntity::class, mappedBy: 'myObjects')]
+    public $theirObjects;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector/config/yaml_mapping/many_to_many.yaml
+++ b/rules-tests/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector/config/yaml_mapping/many_to_many.yaml
@@ -1,0 +1,19 @@
+Rector\Doctrine\Tests\CodeQuality\Rector\Class_\YamlToAttributeDoctrineMappingRector\Fixture\ManyToMany:
+    manyToMany:
+        myObjects:
+            targetEntity: App\SomeTargetEntity
+            inversedBy: theirObjects
+            joinTable:
+                name: owned_objects
+                joinColumns:
+                    owner_id:
+                        referencedColumnName: some_id
+                        onDelete: cascade
+                inverseJoinColumns:
+                    object_id:
+                        referencedColumnName: some_id
+                        onDelete: cascade
+
+        theirObjects:
+            targetEntity: App\SomeTargetEntity
+            mappedBy: myObjects

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/JoinTableAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/JoinTableAttributeTransformer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\CodeQuality\AttributeTransformer\PropertyAttributeTransformer;
+
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Property;
+use Rector\Doctrine\CodeQuality\Contract\PropertyAttributeTransformerInterface;
+use Rector\Doctrine\CodeQuality\Enum\EntityMappingKey;
+use Rector\Doctrine\CodeQuality\Helper\NodeValueNormalizer;
+use Rector\Doctrine\CodeQuality\NodeFactory\AttributeFactory;
+use Rector\Doctrine\CodeQuality\ValueObject\EntityMapping;
+use Rector\Doctrine\Enum\MappingClass;
+use Rector\PhpParser\Node\NodeFactory;
+
+final readonly class JoinTableAttributeTransformer implements PropertyAttributeTransformerInterface
+{
+    public function __construct(
+        private NodeFactory $nodeFactory
+    ) {
+    }
+
+    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    {
+        $joinTableMapping = $entityMapping->matchManyToManyPropertyMapping($property)['joinTable'] ?? null;
+        if (! is_array($joinTableMapping)) {
+            return;
+        }
+
+        // handled by another mapper
+        unset($joinTableMapping['joinColumns'], $joinTableMapping['inverseJoinColumns']);
+
+        $args = $this->nodeFactory->createArgs($joinTableMapping);
+        $property->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
+
+        NodeValueNormalizer::ensureKeyIsClassConstFetch($args, EntityMappingKey::TARGET_ENTITY);
+    }
+
+    public function getClassName(): string
+    {
+        return MappingClass::JOIN_TABLE;
+    }
+}

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/ManyToManyAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/ManyToManyAttributeTransformer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\CodeQuality\AttributeTransformer\PropertyAttributeTransformer;
+
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Property;
+use Rector\Doctrine\CodeQuality\Contract\PropertyAttributeTransformerInterface;
+use Rector\Doctrine\CodeQuality\Enum\EntityMappingKey;
+use Rector\Doctrine\CodeQuality\Helper\NodeValueNormalizer;
+use Rector\Doctrine\CodeQuality\NodeFactory\AttributeFactory;
+use Rector\Doctrine\CodeQuality\ValueObject\EntityMapping;
+use Rector\Doctrine\Enum\MappingClass;
+use Rector\PhpParser\Node\NodeFactory;
+
+final readonly class ManyToManyAttributeTransformer implements PropertyAttributeTransformerInterface
+{
+    public function __construct(
+        private NodeFactory $nodeFactory
+    ) {
+    }
+
+    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    {
+        $manyToManyMapping = $entityMapping->matchManyToManyPropertyMapping($property);
+        if (! is_array($manyToManyMapping)) {
+            return;
+        }
+
+        // handled by another mapper
+        unset($manyToManyMapping['joinTable']);
+
+        $args = $this->nodeFactory->createArgs($manyToManyMapping);
+        $property->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
+
+        NodeValueNormalizer::ensureKeyIsClassConstFetch($args, EntityMappingKey::TARGET_ENTITY);
+    }
+
+    public function getClassName(): string
+    {
+        return MappingClass::MANY_TO_MANY;
+    }
+}

--- a/rules/CodeQuality/ValueObject/EntityMapping.php
+++ b/rules/CodeQuality/ValueObject/EntityMapping.php
@@ -56,6 +56,15 @@ final class EntityMapping
     /**
      * @return array<string, mixed>|null
      */
+    public function matchManyToManyPropertyMapping(Property|Param $property): ?array
+    {
+        $propertyName = $this->getPropertyName($property);
+        return $this->entityMapping['manyToMany'][$propertyName] ?? null;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
     public function matchManyToOnePropertyMapping(Property|Param $property): ?array
     {
         $propertyName = $this->getPropertyName($property);

--- a/src/Enum/MappingClass.php
+++ b/src/Enum/MappingClass.php
@@ -74,6 +74,21 @@ final class MappingClass
     /**
      * @var string
      */
+    public const INVERSE_JOIN_COLUMN = 'Doctrine\ORM\Mapping\InverseJoinColumn';
+
+    /**
+     * @var string
+     */
+    public const JOIN_TABLE = 'Doctrine\ORM\Mapping\JoinTable';
+
+    /**
+     * @var string
+     */
+    public const MANY_TO_MANY = 'Doctrine\ORM\Mapping\ManyToMany';
+
+    /**
+     * @var string
+     */
     public const MANY_TO_ONE = 'Doctrine\ORM\Mapping\ManyToOne';
 
     /**


### PR DESCRIPTION
Adds support for `manyToMany` in yamls to convert into `ManyToMany`/`JoinTable`/`JoinColumn`/`InvserseJoinColumn`.

This will have a little conflict with #307, but is easily resolvable by switching `$manyToOnePropertyMapping` for `$mapping`.