### PR TITLE
Transform indexes from yaml to attributes

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector/Fixture/indexes.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector/Fixture/indexes.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\YamlToAttributeDoctrineMappingRector\Fixture;
+
+final class Indexes
+{
+    private $id;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\YamlToAttributeDoctrineMappingRector\Fixture;
+
+#[\Doctrine\ORM\Mapping\Table]
+#[\Doctrine\ORM\Mapping\Index(name: 'IDX_WHAT_EVER', columns: ['some', 'column'])]
+final class Indexes
+{
+    private $id;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector/config/yaml_mapping/indexes.yml
+++ b/rules-tests/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector/config/yaml_mapping/indexes.yml
@@ -1,0 +1,4 @@
+Rector\Doctrine\Tests\CodeQuality\Rector\Class_\YamlToAttributeDoctrineMappingRector\Fixture\Indexes:
+    indexes:
+        IDX_WHAT_EVER:
+            columns: [some, column]

--- a/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/TableClassAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/TableClassAttributeTransformer.php
@@ -44,6 +44,10 @@ final readonly class TableClassAttributeTransformer implements ClassAttributeTra
         $this->addIndexes($classMapping['uniqueConstraints'] ?? [], $class, MappingClass::UNIQUE_CONSTRAINT);
     }
 
+    /**
+     * @param array<string, array<string, mixed>> $mapping
+     * @param MappingClass::* $attribute
+     */
     private function addIndexes(array $mapping, Class_ $class, string $attribute): void
     {
         foreach ($mapping as $name => $values) {

--- a/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/TableClassAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/TableClassAttributeTransformer.php
@@ -40,14 +40,19 @@ final readonly class TableClassAttributeTransformer implements ClassAttributeTra
 
         $class->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
 
-        $uniqueConstraints = $classMapping['uniqueConstraints'] ?? [];
-        foreach ($uniqueConstraints as $name => $uniqueConstraint) {
-            $uniqueConstraint = array_merge([
-                'name' => $name,
-            ], $uniqueConstraint);
+        $this->addIndexes($classMapping['indexes'] ?? [], $class, MappingClass::INDEX);
+        $this->addIndexes($classMapping['uniqueConstraints'] ?? [], $class, MappingClass::UNIQUE_CONSTRAINT);
+    }
 
-            $args = $this->nodeFactory->createArgs($uniqueConstraint);
-            $class->attrGroups[] = AttributeFactory::createGroup(MappingClass::UNIQUE_CONSTRAINT, $args);
+    private function addIndexes(array $mapping, Class_ $class, string $attribute): void
+    {
+        foreach ($mapping as $name => $values) {
+            $values = array_merge([
+                'name' => $name,
+            ], $values);
+
+            $args = $this->nodeFactory->createArgs($values);
+            $class->attrGroups[] = AttributeFactory::createGroup($attribute, $args);
         }
     }
 

--- a/src/Enum/MappingClass.php
+++ b/src/Enum/MappingClass.php
@@ -69,6 +69,11 @@ final class MappingClass
     /**
      * @var string
      */
+    public const INDEX = 'Doctrine\ORM\Mapping\Index';
+
+    /**
+     * @var string
+     */
     public const MANY_TO_ONE = 'Doctrine\ORM\Mapping\ManyToOne';
 
     /**


### PR DESCRIPTION
Add support for transforming `indexes` in yamls into `Index` class attributes.