### PR TITLE
Add return doc block to Collection property's getter method by ToMany attribute

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,29 @@
-# 19 Rules Overview
+# 20 Rules Overview
+
+## AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector
+
+Adds `@return` PHPDoc type to Collection property getter by *ToMany attribute
+
+- class: [`Rector\Doctrine\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector`](../rules/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector.php)
+
+```diff
+ #[ORM\Entity]
+ final class Trainer
+ {
+     #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+     private $trainings;
+
++    /**
++     * @return \Doctrine\Common\Collections\Collection<int, \Rector\Doctrine\Tests\CodeQuality\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training>
++     */
+     public function getTrainings()
+     {
+         return $this->trainings;
+     }
+ }
+```
+
+<br>
 
 ## ChangeCompositeExpressionAddMultipleWithWithRector
 

--- a/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture/*');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/ManyToMany/getter_with_return_type.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/ManyToMany/getter_with_return_type.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Fixture\ManyToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+#[ORM\Entity]
+final class Trainer
+{
+    #[ORM\ManyToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $trainings;
+
+    public function getTrainings(): Collection
+    {
+        return $this->trainings;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Fixture\ManyToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+#[ORM\Entity]
+final class Trainer
+{
+    #[ORM\ManyToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $trainings;
+
+    /**
+     * @return \Doctrine\Common\Collections\Collection<int, \Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training>
+     */
+    public function getTrainings(): Collection
+    {
+        return $this->trainings;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/OneToMany/getter_with_return_type.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/OneToMany/getter_with_return_type.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+#[ORM\Entity]
+final class Trainer
+{
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $trainings;
+
+    public function getTrainings(): Collection
+    {
+        return $this->trainings;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+#[ORM\Entity]
+final class Trainer
+{
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $trainings;
+
+    /**
+     * @return \Doctrine\Common\Collections\Collection<int, \Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training>
+     */
+    public function getTrainings(): Collection
+    {
+        return $this->trainings;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/OneToMany/getter_without_return_type.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/OneToMany/getter_without_return_type.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+#[ORM\Entity]
+final class Trainer
+{
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $trainings;
+
+    public function getTrainings()
+    {
+        return $this->trainings;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+#[ORM\Entity]
+final class Trainer
+{
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $trainings;
+
+    /**
+     * @return \Doctrine\Common\Collections\Collection<int, \Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training>
+     */
+    public function getTrainings()
+    {
+        return $this->trainings;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/OneToMany/multiple_returned_collection_properties.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/OneToMany/multiple_returned_collection_properties.php.inc
@@ -1,0 +1,57 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+#[ORM\Entity]
+final class Trainer
+{
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $morningTrainings;
+
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $eveningTrainings;
+
+    public function getTrainings(): Collection
+    {
+        if (random_int(0, 1)) {
+            return $this->morningTrainings;
+        }
+
+        return $this->eveningTrainings;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+#[ORM\Entity]
+final class Trainer
+{
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $morningTrainings;
+
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $eveningTrainings;
+
+    public function getTrainings(): Collection
+    {
+        if (random_int(0, 1)) {
+            return $this->morningTrainings;
+        }
+
+        return $this->eveningTrainings;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/OneToMany/not_a_collection_property.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/OneToMany/not_a_collection_property.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+#[ORM\Entity]
+final class Trainer
+{
+    private $trainings;
+
+    public function getTrainings(): Collection
+    {
+        return $this->trainings;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+#[ORM\Entity]
+final class Trainer
+{
+    private $trainings;
+
+    public function getTrainings(): Collection
+    {
+        return $this->trainings;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/OneToMany/not_entity_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/OneToMany/not_entity_class.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+final class Trainer
+{
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $trainings;
+
+    public function getTrainings(): Collection
+    {
+        return $this->trainings;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+final class Trainer
+{
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $trainings;
+
+    public function getTrainings(): Collection
+    {
+        return $this->trainings;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/OneToMany/with_invalid_return_type.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Fixture/OneToMany/with_invalid_return_type.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector\Fixture\OneToMany;
+
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+#[ORM\Entity]
+final class Trainer
+{
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $trainings;
+
+    /**
+     * @return \Doctrine\Common\Collections\Collection<\Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training>
+     */
+    public function getTrainings()
+    {
+        return $this->trainings;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector\Fixture\OneToMany;
+
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training;
+
+#[ORM\Entity]
+final class Trainer
+{
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $trainings;
+
+    /**
+     * @return \Doctrine\Common\Collections\Collection<int, \Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source\Training>
+     */
+    public function getTrainings()
+    {
+        return $this->trainings;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Source/Training.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/Source/Training.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\Source;
+
+final class Training
+{
+
+}

--- a/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector::class);
+};

--- a/rules/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\CodeQuality\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Analyser\Scope;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
+use Rector\Doctrine\CodeQuality\Enum\ToManyMappings;
+use Rector\Doctrine\NodeAnalyzer\AttributeFinder;
+use Rector\Doctrine\NodeAnalyzer\MethodUniqueReturnedPropertyResolver;
+use Rector\Doctrine\NodeAnalyzer\TargetEntityResolver;
+use Rector\Doctrine\TypeAnalyzer\CollectionTypeFactory;
+use Rector\Rector\AbstractScopeAwareRector;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VendorLocker\NodeVendorLocker\ClassMethodReturnTypeOverrideGuard;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ *  @see \Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector\AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRectorTest
+ */
+final class AddReturnDocBlockToCollectionPropertyGetterByToManyAttributeRector extends AbstractScopeAwareRector implements MinPhpVersionInterface
+{
+    public function __construct(
+        private readonly ClassMethodReturnTypeOverrideGuard $classMethodReturnTypeOverrideGuard,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly PhpDocTypeChanger $phpDocTypeChanger,
+        private readonly AttributeFinder $attributeFinder,
+        private readonly TargetEntityResolver $targetEntityResolver,
+        private readonly CollectionTypeFactory $collectionTypeFactory,
+        private readonly MethodUniqueReturnedPropertyResolver $methodUniqueReturnedPropertyResolver,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Adds @return PHPDoc type to Collection property getter by *ToMany attribute', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+#[ORM\Entity]
+final class Trainer
+{
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $trainings;
+
+    public function getTrainings()
+    {
+        return $this->trainings;
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+#[ORM\Entity]
+final class Trainer
+{
+    #[ORM\OneToMany(targetEntity:Training::class, mappedBy:"trainer")]
+    private $trainings;
+
+    /**
+     * @return \Doctrine\Common\Collections\Collection<int, \Rector\Doctrine\Tests\CodeQuality\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training>
+     */
+    public function getTrainings()
+    {
+        return $this->trainings;
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactorWithScope(Node $node, Scope $scope): ?Node
+    {
+        if (! $this->isDoctrineEntityClass($node)) {
+            return null;
+        }
+
+        foreach ($node->getMethods() as $classMethod) {
+            if ($this->classMethodReturnTypeOverrideGuard->shouldSkipClassMethod($classMethod, $scope)) {
+                return null;
+            }
+
+            $property = $this->methodUniqueReturnedPropertyResolver->resolve($node, $classMethod);
+
+            if ($property === null) {
+                continue;
+            }
+
+            $collectionObjectType = $this->getCollectionObjectTypeFromToManyAttribute($property);
+
+            if ($collectionObjectType === null) {
+                return null;
+            }
+
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
+            $newVarType = $this->collectionTypeFactory->createType($collectionObjectType);
+            $this->phpDocTypeChanger->changeReturnType($classMethod, $phpDocInfo, $newVarType);
+        }
+
+        return $node;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ATTRIBUTES;
+    }
+
+    private function getCollectionObjectTypeFromToManyAttribute(Property $property): ?FullyQualifiedObjectType
+    {
+        $targetEntityExpr = $this->attributeFinder->findAttributeByClassesArgByName(
+            $property,
+            ToManyMappings::TO_MANY_CLASSES,
+            'targetEntity'
+        );
+
+        if (! $targetEntityExpr instanceof ClassConstFetch) {
+            return null;
+        }
+
+        $targetEntityClassName = $this->targetEntityResolver->resolveFromExpr($targetEntityExpr);
+
+        if ($targetEntityClassName === null) {
+            return null;
+        }
+
+        return new FullyQualifiedObjectType($targetEntityClassName);
+    }
+
+    private function isDoctrineEntityClass(Class_ $class): bool
+    {
+        $entityAttribute = $this->attributeFinder->findAttributeByClasses(
+            $class,
+            ['Doctrine\ORM\Mapping\Entity', 'Doctrine\ORM\Mapping\Embeddable'],
+        );
+
+        return $entityAttribute !== null;
+    }
+}

--- a/src/NodeAnalyzer/MethodUniqueReturnedPropertyResolver.php
+++ b/src/NodeAnalyzer/MethodUniqueReturnedPropertyResolver.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\NodeAnalyzer;
+
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\Return_;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\PhpParser\Node\BetterNodeFinder;
+
+final readonly class MethodUniqueReturnedPropertyResolver
+{
+    public function __construct(
+        private BetterNodeFinder $betterNodeFinder,
+        private NodeNameResolver $nodeNameResolver
+    ) {
+    }
+
+    public function resolve(Class_ $class, ClassMethod $classMethod): ?Property
+    {
+        $returns = $this->betterNodeFinder->findInstancesOfInFunctionLikeScoped($classMethod, Return_::class);
+
+        if (\count($returns) !== 1) {
+            return null;
+        }
+
+        $return = \reset($returns);
+
+        $returnExpr = $return->expr;
+
+        if (! $returnExpr instanceof PropertyFetch) {
+            return null;
+        }
+
+        $propertyName = (string) $this->nodeNameResolver->getName($returnExpr);
+
+        return $class->getProperty($propertyName);
+    }
+}


### PR DESCRIPTION
As in the title - I added a class, that based on the property's OneToMany or ManyToMany attribute, adds `@return` doc block to a getter method.
It adds the doc block only if method returns single property.
It also fixes invalid doc blocks like `@return Collection<Entity> -> @return Collection<int, Entity>`.

Any feedback appreciated