### PR TITLE
Keep selectable intersection when improving doctrine collection doc type

### DIFF
--- a/rules-tests/CodeQuality/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/OneToMany/Attribute/skip_collection_generic_class_with_selectable.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/OneToMany/Attribute/skip_collection_generic_class_with_selectable.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Fixture\OneToMany\Attribute;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Selectable;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\CountryRef;
+
+#[ORM\Entity]
+class SkipCollectionGenericClass
+{
+	/**
+	 * @var Collection<int, CountryRef>&Selectable<int, CountryRef>
+	 */
+	#[ORM\OneToMany(mappedBy: 'country', targetEntity: CountryRef::class, cascade: ['persist'])]
+	private Collection&Selectable $countryRefs;
+
+	public function __construct()
+	{
+		$this->countryRefs = new ArrayCollection();
+	}
+}

--- a/rules-tests/CodeQuality/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/OneToMany/Attribute/skip_collection_generic_object_with_selectable.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/OneToMany/Attribute/skip_collection_generic_object_with_selectable.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Fixture\OneToMany\Attribute;
+
+use DateTimeImmutable;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Selectable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class SkipCollectionGenericObject
+{
+    /**
+     * @var Collection<int, object>&Selectable<int, object>
+     */
+    #[ORM\OneToMany(mappedBy: 'port', targetEntity: object::class)]
+    private Collection&Selectable $oi;
+
+    public function __construct()
+    {
+        $this->oi = new ArrayCollection();
+    }
+}

--- a/src/TypeAnalyzer/CollectionTypeFactory.php
+++ b/src/TypeAnalyzer/CollectionTypeFactory.php
@@ -6,13 +6,21 @@ namespace Rector\Doctrine\TypeAnalyzer;
 
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
 
 final class CollectionTypeFactory
 {
-    public function createType(ObjectType $objectType): GenericObjectType
+    public function createType(ObjectType $objectType, bool $addSelectableUnion = false): Type
     {
         $genericTypes = [new IntegerType(), $objectType];
-        return new GenericObjectType('Doctrine\Common\Collections\Collection', $genericTypes);
+        $collectionType = new GenericObjectType('Doctrine\Common\Collections\Collection', $genericTypes);
+        if (!$addSelectableUnion) {
+            return $collectionType;
+        }
+
+        $selectableType = new GenericObjectType('Doctrine\Common\Collections\Selectable', $genericTypes);
+        return new IntersectionType([$collectionType, $selectableType]);
     }
 }

--- a/stubs/Common/Collections/ArrayCollection.php
+++ b/stubs/Common/Collections/ArrayCollection.php
@@ -11,7 +11,7 @@ if (class_exists('Doctrine\Common\Collections\ArrayCollection')) {
     return;
 }
 
-class ArrayCollection implements Collection
+class ArrayCollection implements Collection, Selectable
 {
 
     public function add(mixed $element)

--- a/stubs/Common/Collections/Selectable.php
+++ b/stubs/Common/Collections/Selectable.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Common\Collections;
+
+if (interface_exists('Doctrine\Common\Collections\Selectable')) {
+    return;
+}
+
+interface Selectable
+{
+
+}


### PR DESCRIPTION
This is an attempt to fix #342. 

I do have an issue with one of the tests, as the `PhpDocTypeChanger` incorrect detects the types as changed, causing it to change it every time as the test indicates. Some help to fix this would be appreciated, or....

It might actually be better to not touch the doc type at all when it already contains the `<int,`, but I do not think I can implement that correctly (or swiftly)