### PR TITLE
Use normal Collection<ClassName> when property has indexBy

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector/Fixture/OneToMany/with_index_by.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector/Fixture/OneToMany/with_index_by.php.inc
@@ -1,0 +1,62 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector\Source\Training;
+
+#[ORM\Entity()]
+class Trainer
+{
+    /**
+     * @var Collection|Training[]
+     */
+    #[ORM\OneToMany(targetEntity: Training::class, indexBy: "id", mappedBy: "trainer")]
+    private $trainings = [];
+
+    public function getTrainings()
+    {
+        return $this->trainings;
+    }
+
+    public function setTrainings($trainings)
+    {
+        $this->trainings = $trainings;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector\Source\Training;
+
+#[ORM\Entity()]
+class Trainer
+{
+    /**
+     * @var Collection|Training[]
+     */
+    #[ORM\OneToMany(targetEntity: Training::class, indexBy: "id", mappedBy: "trainer")]
+    private $trainings = [];
+
+    /**
+     * @return \Doctrine\Common\Collections\Collection<\Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector\Source\Training>
+     */
+    public function getTrainings()
+    {
+        return $this->trainings;
+    }
+
+    public function setTrainings($trainings)
+    {
+        $this->trainings = $trainings;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector/Source/Training.php
+++ b/rules-tests/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector/Source/Training.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\Tests\CodeQuality\Rector\Class_\AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector\Source;
 
+use Doctrine\ORM\Mapping as ORM;
+
 final class Training
 {
-
+    #[ORM\Column(name: 'id', type: 'string')]
+    #[ORM\Id]
+    private string $id;
 }

--- a/rules-tests/CodeQuality/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/OneToMany/with_index_by.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/OneToMany/with_index_by.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training;
+
+/**
+ * @ORM\Entity
+ */
+class WithIndexBy
+{
+    /**
+     * @ORM\OneToMany(targetEntity=Training::class, mappedBy="trainer", "indexBy"="id")
+     * @var Collection<int, string>|Training[]
+     */
+    private $trainings = [];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Fixture\OneToMany;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training;
+
+/**
+ * @ORM\Entity
+ */
+class WithIndexBy
+{
+    /**
+     * @ORM\OneToMany(targetEntity=Training::class, mappedBy="trainer", "indexBy"="id")
+     * @var \Doctrine\Common\Collections\Collection<\Rector\Doctrine\Tests\CodeQuality\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training>
+     */
+    private $trainings = [];
+}
+
+?>

--- a/rules/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector.php
+++ b/rules/CodeQuality/Rector/Class_/AddReturnDocBlockToCollectionPropertyGetterByToManyAnnotationRector.php
@@ -126,7 +126,10 @@ CODE_SAMPLE
 
             // update docblock with known collection type
             $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-            $newVarType = $this->collectionTypeFactory->createType($collectionObjectType);
+            $newVarType = $this->collectionTypeFactory->createType(
+                $collectionObjectType,
+                $this->collectionTypeResolver->hasIndexBy($property)
+            );
             $this->phpDocTypeChanger->changeReturnType($classMethod, $phpDocInfo, $newVarType);
             $hasChanged = true;
         }

--- a/rules/CodeQuality/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector.php
+++ b/rules/CodeQuality/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector.php
@@ -208,7 +208,10 @@ CODE_SAMPLE
                 return null;
             }
 
-            $newVarType = $this->collectionTypeFactory->createType($collectionObjectType);
+            $newVarType = $this->collectionTypeFactory->createType(
+                $collectionObjectType,
+                $this->collectionTypeResolver->hasIndexBy($property)
+            );
             $this->phpDocTypeChanger->changeVarType($property, $phpDocInfo, $newVarType);
         } else {
             $collectionObjectType = $this->collectionTypeResolver->resolveFromToManyProperty($property);
@@ -216,7 +219,10 @@ CODE_SAMPLE
                 return null;
             }
 
-            $newVarType = $this->collectionTypeFactory->createType($collectionObjectType);
+            $newVarType = $this->collectionTypeFactory->createType(
+                $collectionObjectType,
+                $this->collectionTypeResolver->hasIndexBy($property)
+            );
             $this->phpDocTypeChanger->changeVarType($property, $phpDocInfo, $newVarType);
         }
 
@@ -249,7 +255,10 @@ CODE_SAMPLE
 
         $fullyQualifiedObjectType = new FullyQualifiedObjectType($targetEntityClassName);
 
-        $genericObjectType = $this->collectionTypeFactory->createType($fullyQualifiedObjectType);
+        $genericObjectType = $this->collectionTypeFactory->createType(
+            $fullyQualifiedObjectType,
+            $this->collectionTypeResolver->hasIndexBy($property)
+        );
         $this->phpDocTypeChanger->changeVarType($property, $phpDocInfo, $genericObjectType);
 
         return $property;

--- a/rules/CodeQuality/SetterCollectionResolver.php
+++ b/rules/CodeQuality/SetterCollectionResolver.php
@@ -16,6 +16,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\Doctrine\CodeQuality\Enum\DoctrineClass;
 use Rector\Doctrine\TypeAnalyzer\CollectionTypeFactory;
+use Rector\Doctrine\TypeAnalyzer\CollectionTypeResolver;
 use Rector\Doctrine\TypeAnalyzer\CollectionVarTagValueNodeResolver;
 use Rector\NodeManipulator\AssignManipulator;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -31,7 +32,8 @@ final readonly class SetterCollectionResolver
         private NodeNameResolver $nodeNameResolver,
         private CollectionVarTagValueNodeResolver $collectionVarTagValueNodeResolver,
         private StaticTypeMapper $staticTypeMapper,
-        private CollectionTypeFactory $collectionTypeFactory
+        private CollectionTypeFactory $collectionTypeFactory,
+        private CollectionTypeResolver $collectionTypeResolver
     ) {
     }
 
@@ -80,7 +82,10 @@ final readonly class SetterCollectionResolver
             if (count($nonCollectionTypes) === 1) {
                 $soleType = $nonCollectionTypes[0];
                 if ($soleType instanceof ArrayType && $soleType->getItemType() instanceof ObjectType) {
-                    return $this->collectionTypeFactory->createType($soleType->getItemType());
+                    return $this->collectionTypeFactory->createType(
+                        $soleType->getItemType(),
+                        $this->collectionTypeResolver->hasIndexBy($property)
+                    );
                 }
             }
         }

--- a/src/NodeManipulator/ToManyRelationPropertyTypeResolver.php
+++ b/src/NodeManipulator/ToManyRelationPropertyTypeResolver.php
@@ -19,6 +19,7 @@ use Rector\Doctrine\CodeQuality\Enum\OdmMappingKey;
 use Rector\Doctrine\NodeAnalyzer\AttributeFinder;
 use Rector\Doctrine\PhpDoc\ShortClassExpander;
 use Rector\Doctrine\TypeAnalyzer\CollectionTypeFactory;
+use Rector\Doctrine\TypeAnalyzer\CollectionTypeResolver;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 
@@ -30,6 +31,7 @@ final readonly class ToManyRelationPropertyTypeResolver
         private AttributeFinder $attributeFinder,
         private ValueResolver $valueResolver,
         private CollectionTypeFactory $collectionTypeFactory,
+        private CollectionTypeResolver $collectionTypeResolver
     ) {
     }
 
@@ -92,6 +94,9 @@ final readonly class ToManyRelationPropertyTypeResolver
         $entityFullyQualifiedClass = $this->shortClassExpander->resolveFqnTargetEntity($targetEntity, $property);
         $fullyQualifiedObjectType = new FullyQualifiedObjectType($entityFullyQualifiedClass);
 
-        return $this->collectionTypeFactory->createType($fullyQualifiedObjectType);
+        return $this->collectionTypeFactory->createType(
+            $fullyQualifiedObjectType,
+            $this->collectionTypeResolver->hasIndexBy($property)
+        );
     }
 }

--- a/src/TypeAnalyzer/CollectionTypeFactory.php
+++ b/src/TypeAnalyzer/CollectionTypeFactory.php
@@ -10,9 +10,10 @@ use PHPStan\Type\ObjectType;
 
 final class CollectionTypeFactory
 {
-    public function createType(ObjectType $objectType): GenericObjectType
+    public function createType(ObjectType $objectType, bool $withIndexBy): GenericObjectType
     {
-        $genericTypes = [new IntegerType(), $objectType];
+        $genericTypes = $withIndexBy ? [$objectType] : [new IntegerType(), $objectType];
+
         return new GenericObjectType('Doctrine\Common\Collections\Collection', $genericTypes);
     }
 }

--- a/src/TypeAnalyzer/CollectionTypeResolver.php
+++ b/src/TypeAnalyzer/CollectionTypeResolver.php
@@ -69,7 +69,7 @@ final readonly class CollectionTypeResolver
         return null;
     }
 
-    public function hasIndexBy(Property|Param $property)
+    public function hasIndexBy(Property|Param $property): bool
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($property);
         if ($phpDocInfo instanceof PhpDocInfo && str_contains((string) $phpDocInfo->getPhpDocNode(), 'indexBy')) {

--- a/src/TypeAnalyzer/CollectionTypeResolver.php
+++ b/src/TypeAnalyzer/CollectionTypeResolver.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Attribute;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\NodeTraverser;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
@@ -68,7 +69,7 @@ final readonly class CollectionTypeResolver
         return null;
     }
 
-    public function hasIndexBy(Property $property)
+    public function hasIndexBy(Property|Param $property)
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($property);
         if ($phpDocInfo instanceof PhpDocInfo && str_contains((string) $phpDocInfo->getPhpDocNode(), 'indexBy')) {


### PR DESCRIPTION
Avoid using `<int>` index when property has indexBy.

Fixes https://github.com/rectorphp/rector/issues/8791
Fixes https://github.com/rectorphp/rector-doctrine/issues/357