### PR TITLE
[ORM-300] add missing rename class

### DIFF
--- a/config/sets/doctrine-orm-300.php
+++ b/config/sets/doctrine-orm-300.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Doctrine\ORM\ORMException'   => 'Doctrine\ORM\Exception\ORMException',
+    ]);
+};

--- a/src/Set/DoctrineSetList.php
+++ b/src/Set/DoctrineSetList.php
@@ -72,6 +72,11 @@ final class DoctrineSetList
     /**
      * @var string
      */
+    public const DOCTRINE_ORM_300 = __DIR__ . '/../../config/sets/doctrine-orm-300.php';
+
+    /**
+     * @var string
+     */
     public const DOCTRINE_BUNDLE_210 = __DIR__ . '/../../config/sets/doctrine-bundle-210.php';
 
     /**


### PR DESCRIPTION
@see https://github.com/doctrine/orm/blob/3.3.x/UPGRADE.md#bc-break-exceptionormexception-is-no-longer-a-class-but-an-interface


Should i do more?