### PR TITLE
[ORM-300] add missing set

### DIFF
--- a/config/sets/doctrine-orm-300.php
+++ b/config/sets/doctrine-orm-300.php
@@ -3,9 +3,14 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Doctrine\Orm30\Rector\MethodCall\SetParametersArrayToCollectionRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        SetParametersArrayToCollectionRector::class,
+    ]);
+
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Doctrine\ORM\ORMException' => 'Doctrine\ORM\Exception\ORMException',
     ]);


### PR DESCRIPTION
I also see that `SetParametersArrayToCollectionRector` uses namespace `Orm30` while this should be `Orm300` to be consistent same as we found for: https://github.com/rectorphp/rector-doctrine/issues/306 can i just update the namespace? This would be breaking for people already using this rule on its own