### PR TITLE
[ORM-300] add missing set, run fixer and add CastDoctrineExprToStringRector

### DIFF
--- a/config/sets/doctrine-orm-300.php
+++ b/config/sets/doctrine-orm-300.php
@@ -3,13 +3,12 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Doctrine\Orm30\Rector\MethodCall\CastDoctrineExprToStringRector;
 use Rector\Doctrine\Orm30\Rector\MethodCall\SetParametersArrayToCollectionRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rules([
-        SetParametersArrayToCollectionRector::class,
-    ]);
+    $rectorConfig->rules([SetParametersArrayToCollectionRector::class, CastDoctrineExprToStringRector::class]);
 
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Doctrine\ORM\ORMException' => 'Doctrine\ORM\Exception\ORMException',

--- a/rules-tests/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector/CastDoctrineExprToStringRectorTest.php
+++ b/rules-tests/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector/CastDoctrineExprToStringRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Orm30\Rector\MethodCall\CastDoctrineExprToStringRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class CastDoctrineExprToStringRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/configured_rule.php';
+    }
+}

--- a/rules-tests/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector/Fixture/epr-lower-cast-to-string.php.inc
+++ b/rules-tests/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector/Fixture/epr-lower-cast-to-string.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Orm30\Rector\MethodCall\CastDoctrineExprToStringRector\Fixture;
+
+use Doctrine\ORM\Query\Expr;
+
+final class ExprBuilderCall
+{
+    public function createCustomExprBuilder()
+    {
+        $expr = new Expr();
+        $expr->like($expr->lower('test'), $expr->lower($expr->literal('%' . 'query' . '%')));
+        $expr->like($expr->lower('test')->__toString(), $expr->lower($expr->literal('%' . 'query' . '%'))->__toString());
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Orm30\Rector\MethodCall\CastDoctrineExprToStringRector\Fixture;
+
+use Doctrine\ORM\Query\Expr;
+
+final class ExprBuilderCall
+{
+    public function createCustomExprBuilder()
+    {
+        $expr = new Expr();
+        $expr->like((string) $expr->lower('test'), (string) $expr->lower($expr->literal('%' . 'query' . '%')));
+        $expr->like($expr->lower('test')->__toString(), $expr->lower($expr->literal('%' . 'query' . '%'))->__toString());
+    }
+}
+?>

--- a/rules-tests/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector/Fixture/no-change.php.inc
+++ b/rules-tests/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector/Fixture/no-change.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Orm30\Rector\MethodCall\CastDoctrineExprToStringRector\Fixture;
+
+use Doctrine\ORM\Query\Expr;
+
+final class SkipLiteral
+{
+    public function createCustomExprBuilder()
+    {
+        $expr = new Expr();
+        $expr->eq('column', $expr->literal('value'));
+    }
+}
+?>

--- a/rules-tests/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector/configured_rule.php
+++ b/rules-tests/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector/configured_rule.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([\Rector\Doctrine\Orm30\Rector\MethodCall\CastDoctrineExprToStringRector::class]);

--- a/rules/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector.php
+++ b/rules/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Orm30\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Cast\String_;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://github.com/doctrine/orm/commit/4d73e3ce7801d3bf3254257332e903d8ecea4096
+ */
+final class CastDoctrineExprToStringRector extends AbstractRector
+{
+    /**
+     * @var array<string>
+     */
+    private array $targetMethods = [
+        'like', 'notLike', 'eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'between',
+        'in', 'notIn', 'isMemberOf', 'isInstanceOf',
+    ];
+
+    /**
+     * @var array<string>
+     */
+    private array $exprFuncMethods = [
+        'lower', 'upper', 'length', 'trim', 'avg', 'max', 'min', 'count',
+        'countDistinct', 'exists', 'all', 'some', 'any', 'not', 'abs', 'sqrt',
+    ];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Casts Doctrine Expr\x to string where necessary.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                $statements->add(
+                    $builder->expr()->like(
+                        $builder->expr()->lower($column),
+                        $builder->expr()->lower($builder->expr()->literal('%'.$like.'%'))
+                    )
+                );
+                CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+                $statements->add(
+                    $builder->expr()->like(
+                        (string) $builder->expr()->lower($column),
+                        (string) $builder->expr()->lower($builder->expr()->literal('%'.$like.'%'))
+                    )
+                );
+                CODE_SAMPLE
+                )]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node instanceof MethodCall) {
+            return null;
+        }
+
+        if (! $this->isObjectType($node->var, new ObjectType('Doctrine\ORM\Query\Expr'))) {
+            return null;
+        }
+
+        if (! in_array($this->getName($node->name), $this->targetMethods, true)) {
+            return null;
+        }
+
+        // Iterate through method arguments and cast `Expr\Func` calls to string
+        $hasChanged = false;
+        foreach ($node->args as $arg) {
+            if (! $arg instanceof Arg) {
+                return null;
+            }
+            if ($arg->value instanceof MethodCall
+                && $this->isObjectType($arg->value->var, new ObjectType('Doctrine\ORM\Query\Expr'))
+                && in_array($this->getName($arg->value->name), $this->exprFuncMethods, true)
+            ) {
+                $arg->value = new String_($arg->value);
+                $hasChanged = true;
+            }
+        }
+
+        return $hasChanged ? $node : null;
+    }
+}

--- a/src/Set/DoctrineSetList.php
+++ b/src/Set/DoctrineSetList.php
@@ -79,7 +79,7 @@ final class DoctrineSetList
     /**
      * @var string
      */
-    public const DOCTRINE_ORM_219 = __DIR__.'/../../config/sets/doctrine-orm-219.php';
+    public const DOCTRINE_ORM_219 = __DIR__ . '/../../config/sets/doctrine-orm-219.php';
 
     /**
      * @var string

--- a/src/Set/SetProvider/DoctrineSetProvider.php
+++ b/src/Set/SetProvider/DoctrineSetProvider.php
@@ -79,6 +79,12 @@ final class DoctrineSetProvider implements SetProviderInterface
                 '2.14',
                 __DIR__ . '/../../../config/sets/doctrine-orm-214.php',
             ),
+            new ComposerTriggeredSet(
+                SetGroup::DOCTRINE,
+                'doctrine/orm',
+                '3.0',
+                __DIR__ . '/../../../config/sets/doctrine-orm-300.php',
+            ),
 
             new Set(SetGroup::ATTRIBUTES, 'Doctrine ORM', __DIR__ . '/../../../config/sets/attributes/doctrine.php'),
             new Set(SetGroup::ATTRIBUTES, 'Gedmo', __DIR__ . '/../../../config/sets/attributes/gedmo.php'),


### PR DESCRIPTION
Add missing set @see https://github.com/rectorphp/rector-doctrine/pull/371#issuecomment-2703774044

Run ecs fixer

And add `CastDoctrineExprToStringRector` this will make sure the functions are casted to string where needed now after upgrade you could get errors like: `Uncaught PHP Exception TypeError: "Doctrine\ORM\Query\Expr::like(): Argument #1 ($x) must be of type string, Doctrine\ORM\Query\Expr\Func given, called in x.php on line x" at Expr.php line 459`