### PR TITLE
Fix YamlToAttributeDoctrineMappingRector

### DIFF
--- a/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/EmbeddableClassAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/EmbeddableClassAttributeTransformer.php
@@ -12,16 +12,17 @@ use Rector\Doctrine\Enum\MappingClass;
 
 final class EmbeddableClassAttributeTransformer implements ClassAttributeTransformerInterface
 {
-    public function transform(EntityMapping $entityMapping, Class_ $class): void
+    public function transform(EntityMapping $entityMapping, Class_ $class): bool
     {
         $classMapping = $entityMapping->getClassMapping();
 
         $type = $classMapping['type'] ?? null;
         if ($type !== 'embeddable') {
-            return;
+            return false;
         }
 
         $class->attrGroups[] = AttributeFactory::createGroup($this->getClassName());
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/EntityClassAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/EntityClassAttributeTransformer.php
@@ -19,13 +19,13 @@ final class EntityClassAttributeTransformer implements ClassAttributeTransformer
      */
     private const REPOSITORY_CLASS_KEY = 'repositoryClass';
 
-    public function transform(EntityMapping $entityMapping, Class_ $class): void
+    public function transform(EntityMapping $entityMapping, Class_ $class): bool
     {
         $classMapping = $entityMapping->getClassMapping();
 
         $type = $classMapping['type'] ?? null;
         if ($type !== 'entity') {
-            return;
+            return false;
         }
 
         $args = [];
@@ -37,6 +37,7 @@ final class EntityClassAttributeTransformer implements ClassAttributeTransformer
         }
 
         $class->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/InheritanceClassAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/InheritanceClassAttributeTransformer.php
@@ -24,13 +24,13 @@ final readonly class InheritanceClassAttributeTransformer implements ClassAttrib
     ) {
     }
 
-    public function transform(EntityMapping $entityMapping, Class_ $class): void
+    public function transform(EntityMapping $entityMapping, Class_ $class): bool
     {
         $classMapping = $entityMapping->getClassMapping();
 
         $inheritanceType = $classMapping['inheritanceType'] ?? null;
         if ($inheritanceType === null) {
-            return;
+            return false;
         }
 
         $class->attrGroups[] = AttributeFactory::createGroup(MappingClass::INHERITANCE_TYPE, [$inheritanceType]);
@@ -45,6 +45,7 @@ final readonly class InheritanceClassAttributeTransformer implements ClassAttrib
         if (isset($classMapping['discriminatorMap'])) {
             $this->addDiscriminatorMap($classMapping['discriminatorMap'], $class);
         }
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/SoftDeletableClassAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/SoftDeletableClassAttributeTransformer.php
@@ -20,13 +20,13 @@ final readonly class SoftDeletableClassAttributeTransformer implements ClassAttr
     ) {
     }
 
-    public function transform(EntityMapping $entityMapping, Class_ $class): void
+    public function transform(EntityMapping $entityMapping, Class_ $class): bool
     {
         $classMapping = $entityMapping->getClassMapping();
 
         $softDeletableMapping = $classMapping['gedmo']['soft_deleteable'] ?? null;
         if (! is_array($softDeletableMapping)) {
-            return;
+            return false;
         }
 
         $args = $this->nodeFactory->createArgs($softDeletableMapping);
@@ -40,6 +40,7 @@ final readonly class SoftDeletableClassAttributeTransformer implements ClassAttr
         }
 
         $class->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/TableClassAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/ClassAttributeTransformer/TableClassAttributeTransformer.php
@@ -24,13 +24,13 @@ final readonly class TableClassAttributeTransformer implements ClassAttributeTra
     ) {
     }
 
-    public function transform(EntityMapping $entityMapping, Class_ $class): void
+    public function transform(EntityMapping $entityMapping, Class_ $class): bool
     {
         $classMapping = $entityMapping->getClassMapping();
 
         $table = $classMapping[self::TABLE_KEY] ?? null;
         if (isset($classMapping['type']) && $classMapping['type'] !== 'entity') {
-            return;
+            return false;
         }
 
         $args = [];
@@ -42,6 +42,7 @@ final readonly class TableClassAttributeTransformer implements ClassAttributeTra
 
         $this->addIndexes($classMapping['indexes'] ?? [], $class, MappingClass::INDEX);
         $this->addIndexes($classMapping['uniqueConstraints'] ?? [], $class, MappingClass::UNIQUE_CONSTRAINT);
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/ColumnAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/ColumnAttributeTransformer.php
@@ -20,11 +20,11 @@ final readonly class ColumnAttributeTransformer implements PropertyAttributeTran
     ) {
     }
 
-    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    public function transform(EntityMapping $entityMapping, Property|Param $property): bool
     {
         $propertyMapping = $entityMapping->matchFieldPropertyMapping($property);
         if ($propertyMapping === null) {
-            return;
+            return false;
         }
 
         // handled in another mapper
@@ -42,6 +42,7 @@ final readonly class ColumnAttributeTransformer implements PropertyAttributeTran
 
         $args = array_merge($args, $this->nodeFactory->createArgs($propertyMapping));
         $property->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/EmbeddedPropertyAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/EmbeddedPropertyAttributeTransformer.php
@@ -20,11 +20,11 @@ final readonly class EmbeddedPropertyAttributeTransformer implements PropertyAtt
     ) {
     }
 
-    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    public function transform(EntityMapping $entityMapping, Property|Param $property): bool
     {
         $propertyMapping = $entityMapping->matchEmbeddedPropertyMapping($property);
         if ($propertyMapping === null) {
-            return;
+            return false;
         }
 
         // handled in another attribute
@@ -34,6 +34,7 @@ final readonly class EmbeddedPropertyAttributeTransformer implements PropertyAtt
         $property->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
 
         NodeValueNormalizer::ensureKeyIsClassConstFetch($args, 'class');
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/GedmoTimestampableAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/GedmoTimestampableAttributeTransformer.php
@@ -19,17 +19,18 @@ final readonly class GedmoTimestampableAttributeTransformer implements PropertyA
     ) {
     }
 
-    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    public function transform(EntityMapping $entityMapping, Property|Param $property): bool
     {
         $fieldPropertyMapping = $entityMapping->matchFieldPropertyMapping($property);
 
         $timestampableMapping = $fieldPropertyMapping['gedmo']['timestampable'] ?? null;
         if (! is_array($timestampableMapping)) {
-            return;
+            return false;
         }
 
         $args = $this->nodeFactory->createArgs($timestampableMapping);
         $property->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/IdAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/IdAttributeTransformer.php
@@ -13,14 +13,15 @@ use Rector\Doctrine\Enum\MappingClass;
 
 final class IdAttributeTransformer implements PropertyAttributeTransformerInterface
 {
-    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    public function transform(EntityMapping $entityMapping, Property|Param $property): bool
     {
         $idMapping = $entityMapping->matchIdPropertyMapping($property);
         if (! is_array($idMapping)) {
-            return;
+            return false;
         }
 
         $property->attrGroups[] = AttributeFactory::createGroup($this->getClassName());
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/IdColumnAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/IdColumnAttributeTransformer.php
@@ -13,11 +13,11 @@ use Rector\Doctrine\Enum\MappingClass;
 
 final class IdColumnAttributeTransformer implements PropertyAttributeTransformerInterface
 {
-    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    public function transform(EntityMapping $entityMapping, Property|Param $property): bool
     {
         $idMapping = $entityMapping->matchIdPropertyMapping($property);
         if (! is_array($idMapping)) {
-            return;
+            return false;
         }
 
         $args = [];
@@ -28,6 +28,7 @@ final class IdColumnAttributeTransformer implements PropertyAttributeTransformer
         }
 
         $property->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/IdGeneratorAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/IdGeneratorAttributeTransformer.php
@@ -27,16 +27,16 @@ final readonly class IdGeneratorAttributeTransformer implements PropertyAttribut
     ) {
     }
 
-    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    public function transform(EntityMapping $entityMapping, Property|Param $property): bool
     {
         $idMapping = $entityMapping->matchIdPropertyMapping($property);
         if (! is_array($idMapping)) {
-            return;
+            return false;
         }
 
         $generator = $idMapping[EntityMappingKey::GENERATOR] ?? null;
         if (! is_array($generator)) {
-            return;
+            return false;
         }
 
         // make sure strategy is uppercase as constant value
@@ -44,6 +44,7 @@ final readonly class IdGeneratorAttributeTransformer implements PropertyAttribut
 
         $args = $this->nodeFactory->createArgs($generator);
         $property->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/InverseJoinColumnAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/InverseJoinColumnAttributeTransformer.php
@@ -20,21 +20,22 @@ final readonly class InverseJoinColumnAttributeTransformer implements PropertyAt
     ) {
     }
 
-    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    public function transform(EntityMapping $entityMapping, Property|Param $property): bool
     {
         $joinTableMapping = $entityMapping->matchManyToManyPropertyMapping($property)['joinTable'] ?? null;
         if (! is_array($joinTableMapping)) {
-            return;
+            return false;
         }
 
         $joinColumns = $joinTableMapping['inverseJoinColumns'] ?? null;
         if (! is_array($joinColumns)) {
-            return;
+            return false;
         }
 
         foreach ($joinColumns as $columnName => $joinColumn) {
             $property->attrGroups[] = $this->createInverseJoinColumnAttrGroup($columnName, $joinColumn);
         }
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/JoinTableAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/JoinTableAttributeTransformer.php
@@ -21,11 +21,11 @@ final readonly class JoinTableAttributeTransformer implements PropertyAttributeT
     ) {
     }
 
-    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    public function transform(EntityMapping $entityMapping, Property|Param $property): bool
     {
         $joinTableMapping = $entityMapping->matchManyToManyPropertyMapping($property)['joinTable'] ?? null;
         if (! is_array($joinTableMapping)) {
-            return;
+            return false;
         }
 
         // handled by another mapper
@@ -35,6 +35,7 @@ final readonly class JoinTableAttributeTransformer implements PropertyAttributeT
         $property->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
 
         NodeValueNormalizer::ensureKeyIsClassConstFetch($args, EntityMappingKey::TARGET_ENTITY);
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/ManyToManyAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/ManyToManyAttributeTransformer.php
@@ -21,11 +21,11 @@ final readonly class ManyToManyAttributeTransformer implements PropertyAttribute
     ) {
     }
 
-    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    public function transform(EntityMapping $entityMapping, Property|Param $property): bool
     {
         $manyToManyMapping = $entityMapping->matchManyToManyPropertyMapping($property);
         if (! is_array($manyToManyMapping)) {
-            return;
+            return false;
         }
 
         // handled by another mapper
@@ -35,6 +35,7 @@ final readonly class ManyToManyAttributeTransformer implements PropertyAttribute
         $property->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
 
         NodeValueNormalizer::ensureKeyIsClassConstFetch($args, EntityMappingKey::TARGET_ENTITY);
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/ManyToOneAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/ManyToOneAttributeTransformer.php
@@ -21,11 +21,11 @@ final readonly class ManyToOneAttributeTransformer implements PropertyAttributeT
     ) {
     }
 
-    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    public function transform(EntityMapping $entityMapping, Property|Param $property): bool
     {
         $manyToOneMapping = $entityMapping->matchManyToOnePropertyMapping($property);
         if (! is_array($manyToOneMapping)) {
-            return;
+            return false;
         }
 
         // handled by another mapper
@@ -38,6 +38,7 @@ final readonly class ManyToOneAttributeTransformer implements PropertyAttributeT
         $property->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
 
         NodeValueNormalizer::ensureKeyIsClassConstFetch($args, EntityMappingKey::TARGET_ENTITY);
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/OneToManyAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/OneToManyAttributeTransformer.php
@@ -21,11 +21,11 @@ final readonly class OneToManyAttributeTransformer implements PropertyAttributeT
     ) {
     }
 
-    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    public function transform(EntityMapping $entityMapping, Property|Param $property): bool
     {
         $oneToManyMapping = $entityMapping->matchOneToManyPropertyMapping($property);
         if (! is_array($oneToManyMapping)) {
-            return;
+            return false;
         }
 
         // handled by OrderBy mapping rule as standalone entity class
@@ -35,6 +35,7 @@ final readonly class OneToManyAttributeTransformer implements PropertyAttributeT
         NodeValueNormalizer::ensureKeyIsClassConstFetch($args, EntityMappingKey::TARGET_ENTITY);
 
         $property->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/OrderByAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/PropertyAttributeTransformer/OrderByAttributeTransformer.php
@@ -20,22 +20,23 @@ final readonly class OrderByAttributeTransformer implements PropertyAttributeTra
     ) {
     }
 
-    public function transform(EntityMapping $entityMapping, Property|Param $property): void
+    public function transform(EntityMapping $entityMapping, Property|Param $property): bool
     {
         $oneToManyMapping = $entityMapping->matchOneToManyPropertyMapping($property);
         if (! is_array($oneToManyMapping)) {
-            return;
+            return false;
         }
 
         // we handle OrderBy here only
         if (! isset($oneToManyMapping[EntityMappingKey::ORDER_BY])) {
-            return;
+            return false;
         }
 
         $orderBy = $oneToManyMapping[EntityMappingKey::ORDER_BY];
         $args = $this->nodeFactory->createArgs([$orderBy]);
 
         $property->attrGroups[] = AttributeFactory::createGroup($this->getClassName(), $args);
+        return true;
     }
 
     public function getClassName(): string

--- a/rules/CodeQuality/AttributeTransformer/YamlToAttributeTransformer.php
+++ b/rules/CodeQuality/AttributeTransformer/YamlToAttributeTransformer.php
@@ -25,39 +25,49 @@ final readonly class YamlToAttributeTransformer
     ) {
     }
 
-    public function transform(Class_ $class, EntityMapping $entityMapping): void
+    public function transform(Class_ $class, EntityMapping $entityMapping): bool
     {
-        $this->transformClass($class, $entityMapping);
-        $this->transformProperties($class, $entityMapping);
+        $hasTrasnformedClass = $this->transformClass($class, $entityMapping);
+        $hasTrasnformedProperties = $this->transformProperties($class, $entityMapping);
+        return $hasTrasnformedClass || $hasTrasnformedProperties;
     }
 
-    private function transformClass(Class_ $class, EntityMapping $entityMapping): void
+    private function transformClass(Class_ $class, EntityMapping $entityMapping): bool
     {
+        $hasChanged = false;
         foreach ($this->classAttributeTransformers as $classAttributeTransformer) {
             if ($this->hasAttribute($class, $classAttributeTransformer->getClassName())) {
                 continue;
             }
 
-            $classAttributeTransformer->transform($entityMapping, $class);
+            $hasTransformedAttribute = $classAttributeTransformer->transform($entityMapping, $class);
+            if ($hasTransformedAttribute) {
+                $hasChanged = true;
+            }
         }
+        return $hasChanged;
     }
 
-    private function transformProperties(Class_ $class, EntityMapping $entityMapping): void
+    private function transformProperties(Class_ $class, EntityMapping $entityMapping): bool
     {
+        $hasChanged = false;
         foreach ($class->getProperties() as $property) {
             foreach ($this->propertyAttributeTransformers as $propertyAttributeTransformer) {
                 if ($this->hasAttribute($property, $propertyAttributeTransformer->getClassName())) {
                     continue;
                 }
 
-                $propertyAttributeTransformer->transform($entityMapping, $property);
+                $hasTransformedAttribute = $propertyAttributeTransformer->transform($entityMapping, $property);
+                if ($hasTransformedAttribute) {
+                    $hasChanged = true;
+                }
             }
         }
 
         // handle promoted properties
         $constructorClassMethod = $class->getMethod(MethodName::CONSTRUCT);
         if (! $constructorClassMethod instanceof ClassMethod) {
-            return;
+            return $hasChanged;
         }
 
         foreach ($constructorClassMethod->getParams() as $param) {
@@ -71,9 +81,13 @@ final readonly class YamlToAttributeTransformer
                     continue;
                 }
 
-                $propertyAttributeTransformer->transform($entityMapping, $param);
+                $hasTransformedAttribute = $propertyAttributeTransformer->transform($entityMapping, $param);
+                if ($hasTransformedAttribute) {
+                    $hasChanged = true;
+                }
             }
         }
+        return $hasChanged;
     }
 
     private function hasAttribute(Class_|Property|Param $stmt, string $attributeClassName): bool

--- a/rules/CodeQuality/Contract/ClassAttributeTransformerInterface.php
+++ b/rules/CodeQuality/Contract/ClassAttributeTransformerInterface.php
@@ -15,5 +15,5 @@ interface ClassAttributeTransformerInterface
      */
     public function getClassName(): string;
 
-    public function transform(EntityMapping $entityMapping, Class_ $class): void;
+    public function transform(EntityMapping $entityMapping, Class_ $class): bool;
 }

--- a/rules/CodeQuality/Contract/PropertyAttributeTransformerInterface.php
+++ b/rules/CodeQuality/Contract/PropertyAttributeTransformerInterface.php
@@ -15,5 +15,5 @@ interface PropertyAttributeTransformerInterface
      */
     public function getClassName(): string;
 
-    public function transform(EntityMapping $entityMapping, Property|Param $property): void;
+    public function transform(EntityMapping $entityMapping, Property|Param $property): bool;
 }

--- a/rules/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector.php
+++ b/rules/CodeQuality/Rector/Class_/YamlToAttributeDoctrineMappingRector.php
@@ -92,7 +92,11 @@ CODE_SAMPLE
             return null;
         }
 
-        $this->yamlToAttributeTransformer->transform($node, $entityMapping);
+        $hasChanged = $this->yamlToAttributeTransformer->transform($node, $entityMapping);
+
+        if (! $hasChanged) {
+            return null;
+        }
 
         return $node;
     }


### PR DESCRIPTION
Fixes one of the issues found by https://github.com/rectorphp/rector-src/pull/6794 in this repository. The `YamlToAttributeDoctrineMappingRector` rule needs to check that any change has actually been made before returning a node, if no change was made it needs to return null. For this we need to change all the hierarchy of functions called by this rector rule, including all classes implementing the `PropertyAttributeTransformerInterface` and `ClassAttributeTransformerInterface`