### PR TITLE
[NodeAnalyzer] Handle no repositoryClass on RepositoryClassResolver

### DIFF
--- a/src/NodeAnalyzer/RepositoryClassResolver.php
+++ b/src/NodeAnalyzer/RepositoryClassResolver.php
@@ -56,6 +56,10 @@ final readonly class RepositoryClassResolver
             $repositoryClass = $match['repositoryClass'];
         }
 
+        if ($repositoryClass === null) {
+            return null;
+        }
+
         if (! $this->reflectionProvider->hasClass($repositoryClass)) {
             throw new ShouldNotHappenException(
                 sprintf('Repository class "%s" for entity "%s" does not exist', $repositoryClass, $entityClassName)


### PR DESCRIPTION
avoid error:

```
         "System error: "PHPStan\Reflection\ReflectionProvider\MemoizingReflectionProvider::hasClass(): Argument #1     
         ($className) must be of type string, null given, called in   
```