### PR TITLE
Update deprecated ArrayItem, Lnumber to use under Node, and Int_ instead

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -17,9 +17,9 @@ return RectorConfig::configure()
         deadCode: true,
         codeQuality: true,
         codingStyle: true,
-        naming: true,
         typeDeclarations: true,
         privatization: true,
+        naming: true,
         rectorPreset: true
     )
     ->withConfiguredRule(StringClassNameToClassConstantRector::class, [

--- a/rules/Dbal40/Rector/StmtsAwareInterface/ExecuteQueryParamsToBindValueRector.php
+++ b/rules/Dbal40/Rector/StmtsAwareInterface/ExecuteQueryParamsToBindValueRector.php
@@ -10,7 +10,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Plus;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\NodeFinder;
@@ -126,7 +126,7 @@ CODE_SAMPLE
             'keyVar' => $positionVariable,
         ]);
         $bindValueMethodCall = new MethodCall($statementExpr, 'bindValue', [
-            new Arg(new Plus($positionVariable, new LNumber(1))),
+            new Arg(new Plus($positionVariable, new Int_(1))),
             new Arg($parameterVariable),
         ]);
 

--- a/rules/Dbal42/Rector/New_/AddArrayResultColumnNamesRector.php
+++ b/rules/Dbal42/Rector/New_/AddArrayResultColumnNamesRector.php
@@ -12,7 +12,7 @@ use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name;
-use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\Int_;
 use Rector\Doctrine\Enum\DoctrineClass;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -92,7 +92,7 @@ CODE_SAMPLE
             ->value;
 
         // pass column names as 1st argument
-        $arrayDimFetch = new ArrayDimFetch($itemsExpr, new LNumber(0));
+        $arrayDimFetch = new ArrayDimFetch($itemsExpr, new Int_(0));
         $arrayCoalesce = new Coalesce($arrayDimFetch, new Array_());
 
         $arrayKeysFuncCall = new FuncCall(new Name('array_keys'), [new Arg($arrayCoalesce)]);

--- a/rules/Orm30/Rector/MethodCall/SetParametersArrayToCollectionRector.php
+++ b/rules/Orm30/Rector/MethodCall/SetParametersArrayToCollectionRector.php
@@ -9,14 +9,14 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayDimFetch;
-use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
-use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PHPStan\Type\ObjectType;
@@ -241,7 +241,7 @@ final class SetParametersArrayToCollectionRector extends AbstractRector
                 'Doctrine\\ORM\\Query\\Parameter'
             )->yes()) {
                 $newParameter = new New_(new FullyQualified('Doctrine\\ORM\\Query\\Parameter'));
-                $newParameter->args = [new Arg($value->key ?? new LNumber($index)), new Arg($value->value)];
+                $newParameter->args = [new Arg($value->key ?? new Int_($index)), new Arg($value->value)];
                 $value->value = $newParameter;
                 $changedParameterType = true;
             }


### PR DESCRIPTION
on php-parser 5, ArrayItem is under Node
on php-parser 5, Lnumber is changed to Int_