### PR TITLE
[DRAFT] Kick off NamespaceAliasRector rule.

### DIFF
--- a/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/Fixture/alias_attributes.php.inc
+++ b/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/Fixture/alias_attributes.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Namespace_\NamespaceAliasRector\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Attribute\Document;
+use Doctrine\ODM\MongoDB\Mapping\Attribute\Id;
+use Doctrine\ODM\MongoDB\Mapping\Attribute\Version;
+use Some\OtherImport;
+
+#[Document]
+final class Post
+{
+    #[Id]
+    private string $id;
+
+    #[Version]
+    private int $version;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Namespace_\NamespaceAliasRector\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+use Some\OtherImport;
+
+#[ODM\Document]
+final class Post
+{
+    #[ODM\Id]
+    private string $id;
+
+    #[ODM\Version]
+    private int $version;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/Fixture/group_and_alias.php.inc
+++ b/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/Fixture/group_and_alias.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Namespace_\NamespaceAliasRector\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Attribute\{Document, EmbedOne as Embedded};
+use Doctrine\ODM\MongoDB\Mapping\Attribute\EmbedMany as Many;
+use Some\OtherImport;
+
+#[Document]
+final class Blog
+{
+    #[Embedded]
+    public Post $post;
+
+    #[Many]
+    public array $comments;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Namespace_\NamespaceAliasRector\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+use Some\OtherImport;
+
+#[ODM\Document]
+final class Blog
+{
+    #[ODM\EmbedOne]
+    public Post $post;
+
+    #[ODM\EmbedMany]
+    public array $comments;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/Fixture/orm_attributes.php.inc
+++ b/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/Fixture/orm_attributes.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Namespace_\NamespaceAliasRector\Fixture;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Some\OtherImport;
+
+#[Entity]
+final class Article
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    public int $id;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Namespace_\NamespaceAliasRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Some\OtherImport;
+
+#[ORM\Entity]
+final class Article
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    public int $id;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/Fixture/partial_aliased.php.inc
+++ b/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/Fixture/partial_aliased.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Namespace_\NamespaceAliasRector\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+use Doctrine\ODM\MongoDB\Mapping\Attribute\Id;
+
+#[ODM\Document]
+final class BlogPost
+{
+    #[Id]
+    private string $id;
+
+    #[ODM\Field]
+    private string $title;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Namespace_\NamespaceAliasRector\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+
+#[ODM\Document]
+final class BlogPost
+{
+    #[ODM\Id]
+    private string $id;
+
+    #[ODM\Field]
+    private string $title;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/Fixture/skip_already_aliased.php.inc
+++ b/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/Fixture/skip_already_aliased.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Namespace_\NamespaceAliasRector\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+
+#[ODM\Document]
+final class BlogPost
+{
+    #[ODM\Id]
+    private string $id;
+
+    #[ODM\Field]
+    private string $title;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Namespace_\NamespaceAliasRector\Fixture;
+
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+
+#[ODM\Document]
+final class BlogPost
+{
+    #[ODM\Id]
+    private string $id;
+
+    #[ODM\Field]
+    private string $title;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/NamespaceAliasRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/NamespaceAliasRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Namespace_\NamespaceAliasRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class NamespaceAliasRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/Namespace_/NamespaceAliasRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\CodeQuality\Rector\Namespace_\NamespaceAliasRector;
+use Rector\Doctrine\CodeQuality\ValueObject\NamespaceAlias;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(NamespaceAliasRector::class, [
+        new NamespaceAlias('Doctrine\\ORM\\Mapping', 'ORM'),
+        new NamespaceAlias('Doctrine\\ODM\\MongoDB\\Mapping\\Attribute', 'ODM'),
+    ]);
+};

--- a/rules/CodeQuality/Rector/Namespace_/NamespaceAliasRector.php
+++ b/rules/CodeQuality/Rector/Namespace_/NamespaceAliasRector.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\CodeQuality\Rector\Namespace_;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\GroupUse;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\UseItem;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Doctrine\CodeQuality\ValueObject\NamespaceAlias;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \Rector\Doctrine\Tests\CodeQuality\Rector\Namespace_\NamespaceAliasRector\NamespaceAliasRectorTest
+ */
+final class NamespaceAliasRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var NamespaceAlias[]
+     */
+    private array $namespaceAliases = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Alias namespaces (e.g. ORM\ODM) and prefix usages accordingly.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ODM\MongoDB\Mapping\Attribute\Document;
+
+#[Entity]
+final class PostEntity
+{
+}
+
+#[Document]
+final class PostDocument
+{
+}
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ODM\MongoDB\Mapping\Attribute as ODM;
+
+#[ORM\Entity]
+final class PostEntity
+{
+}
+
+#[ODM\Document]
+final class PostDocument
+{
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Namespace_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node instanceof Namespace_) {
+            return null;
+        }
+
+        $aliasMaps = [];
+
+        foreach ($this->namespaceAliases as $namespaceAlias) {
+            $aliasAlreadyPresent = $this->hasAliasImport($node, $namespaceAlias);
+
+            $aliasToShort = $this->collectAndRemoveUses($node, $namespaceAlias);
+
+            if ($aliasToShort === []) {
+                continue;
+            }
+
+            if (! $aliasAlreadyPresent) {
+                $this->addAliasImport($node, $namespaceAlias);
+            }
+
+            $aliasMaps[] = [$namespaceAlias, $aliasToShort];
+        }
+
+        if ($aliasMaps === []) {
+            return null;
+        }
+
+        $this->replaceNamesWithAlias($node, $aliasMaps);
+
+        return $node;
+    }
+
+    public function configure(array $configuration): void
+    {
+        Assert::allIsInstanceOf($configuration, NamespaceAlias::class);
+
+        $this->namespaceAliases = $configuration;
+    }
+
+    private function hasAliasImport(Namespace_ $namespace, NamespaceAlias $namespaceAlias): bool
+    {
+        foreach ($namespace->stmts as $stmt) {
+            if (! $stmt instanceof Use_) {
+                continue;
+            }
+
+            foreach ($stmt->uses as $useItem) {
+                if (! $this->isName($useItem->name, $namespaceAlias->getNamespace())) {
+                    continue;
+                }
+
+                if ($useItem->alias?->toString() === $namespaceAlias->getAlias()) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, string> Alias/imported-name to short class name map
+     */
+    private function collectAndRemoveUses(
+        Namespace_ $namespace,
+        NamespaceAlias $namespaceAlias
+    ): array {
+        $aliasToShort = [];
+        $newStmts = [];
+
+        foreach ($namespace->stmts as $stmt) {
+            if ($stmt instanceof Use_) {
+                $result = $this->filterUse($stmt, $namespaceAlias);
+                if ($result['use'] !== null) {
+                    $newStmts[] = $result['use'];
+                }
+
+                $aliasToShort = array_merge($aliasToShort, $result['aliases']);
+
+                continue;
+            }
+
+            if ($stmt instanceof GroupUse && $this->isName($stmt->prefix, $namespaceAlias->getNamespace())) {
+                foreach ($stmt->uses as $useUse) {
+                    $shortName = $useUse->name->getLast();
+                    $alias = $useUse->alias?->toString() ?? $shortName;
+
+                    $aliasToShort[$alias] = $shortName;
+                }
+
+                continue;
+            }
+
+            $newStmts[] = $stmt;
+        }
+
+        $namespace->stmts = $newStmts;
+
+        return $aliasToShort;
+    }
+
+    /**
+     * @param array{NamespaceAlias,array<string,string>}[] $aliasMaps
+     */
+    private function replaceNamesWithAlias(Namespace_ $namespace, array $aliasMaps): void
+    {
+        $this->traverseNodesWithCallable($namespace, function (Node $node) use ($aliasMaps): ?Name {
+            if (! $node instanceof Name) {
+                return null;
+            }
+
+            foreach ($aliasMaps as [$namespaceAlias, $aliasToShort]) {
+                foreach ($aliasToShort as $alias => $shortName) {
+                    $targetFqn = $namespaceAlias->getNamespace() . '\\' . $shortName;
+
+                    if ($this->isName($node, $targetFqn) || $this->isName($node, $alias)) {
+                        return new Name($namespaceAlias->getAlias() . '\\' . $shortName);
+                    }
+                }
+            }
+
+            return null;
+        });
+    }
+
+    /**
+     * @return array{use: ?Use_, aliases: array<string, string>}
+     */
+    private function filterUse(Use_ $use, NamespaceAlias $namespaceAlias): array
+    {
+        $newUses = [];
+        $aliases = [];
+
+        foreach ($use->uses as $useUse) {
+            $useName = $useUse->name->toString();
+
+            if (! str_starts_with($useName, $namespaceAlias->getNamespace() . '\\')) {
+                $newUses[] = $useUse;
+                continue;
+            }
+
+            $shortName = $useUse->name->getLast();
+            $alias = $useUse->alias?->toString() ?? $shortName;
+
+            $aliases[$alias] = $shortName;
+        }
+
+        if ($newUses === []) {
+            return [
+                'use' => null,
+                'aliases' => $aliases,
+            ];
+        }
+
+        $use->uses = $newUses;
+
+        return [
+            'use' => $use,
+            'aliases' => $aliases,
+        ];
+    }
+
+    private function addAliasImport(Namespace_ $namespace, NamespaceAlias $namespaceAlias): void
+    {
+        $aliasUse = new Use_([
+            new UseItem(new Name($namespaceAlias->getNamespace()), new Identifier(
+                $namespaceAlias->getAlias()
+            )),
+        ]);
+
+        $useInserted = false;
+        $newStmts = [];
+
+        foreach ($namespace->stmts as $stmt) {
+            if (! $useInserted && ($stmt instanceof Use_ || $stmt instanceof GroupUse)) {
+                $newStmts[] = $aliasUse;
+                $useInserted = true;
+            }
+
+            if (! $useInserted && ! $stmt instanceof Use_ && ! $stmt instanceof GroupUse) {
+                $newStmts[] = $aliasUse;
+                $useInserted = true;
+            }
+
+            $newStmts[] = $stmt;
+        }
+
+        if (! $useInserted) {
+            $newStmts[] = $aliasUse;
+        }
+
+        $namespace->stmts = $newStmts;
+    }
+}

--- a/rules/CodeQuality/ValueObject/NamespaceAlias.php
+++ b/rules/CodeQuality/ValueObject/NamespaceAlias.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\CodeQuality\ValueObject;
+
+final readonly class NamespaceAlias
+{
+    public function __construct(
+        private string $namespace,
+        private string $alias,
+    ) {}
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+
+    public function getAlias(): string
+    {
+        return $this->alias;
+    }
+}


### PR DESCRIPTION
In https://github.com/rectorphp/rector-doctrine/pull/477#issuecomment-3778083574 I came up with the idea of creating a code quality rule to introduce namespace aliases because they are thoroughly used in the Doctrine documentation when using Entities and Documents.

**Disclaimer:** This is a very rough draft, created with the help of the Copilot Agent, thoughts, help and advice are very much appreciated. Maybe this rule shouldn't even be limited to `rector-doctrine`.