### PR TITLE
Detect associative array of params in ExecuteQueryParamsToBindValueRector

### DIFF
--- a/rules-tests/Dbal40/Rector/StmtsAwareInterface/ExecuteQueryParamsToBindValueRector/Fixture/associative_params.php.inc
+++ b/rules-tests/Dbal40/Rector/StmtsAwareInterface/ExecuteQueryParamsToBindValueRector/Fixture/associative_params.php.inc
@@ -6,8 +6,11 @@ namespace Rector\Doctrine\Tests\Dbal40\Rector\StmtsAwareInterface\ExecuteQueryPa
 
 use Doctrine\DBAL\Statement;
 
-final class SomeFileWithExecute
+final class AssociativeParams
 {
+    /**
+     * @param array<string, mixed> $params
+     */
     public function run(Statement $statement, array $params): void
     {
         $result = $statement->executeQuery($params);
@@ -24,8 +27,11 @@ namespace Rector\Doctrine\Tests\Dbal40\Rector\StmtsAwareInterface\ExecuteQueryPa
 
 use Doctrine\DBAL\Statement;
 
-final class SomeFileWithExecute
+final class AssociativeParams
 {
+    /**
+     * @param array<string, mixed> $params
+     */
     public function run(Statement $statement, array $params): void
     {
         foreach ($params as $key => $parameter) {

--- a/rules/Dbal40/Rector/StmtsAwareInterface/ExecuteQueryParamsToBindValueRector.php
+++ b/rules/Dbal40/Rector/StmtsAwareInterface/ExecuteQueryParamsToBindValueRector.php
@@ -8,8 +8,11 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Plus;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Foreach_;
@@ -44,7 +47,7 @@ class SomeClass
 {
     public function run(Statement $statement, array $params): void
     {
-        $result = $statement->executeQuery($params)
+        $result = $statement->executeQuery($params);
     }
 }
 CODE_SAMPLE
@@ -56,8 +59,8 @@ class SomeClass
 {
     public function run(Statement $statement, array $params): void
     {
-        foreach ($params as $key=> $value) {
-            $statement->bindValue($key + 1, $value);
+        foreach ($params as $key => $parameter) {
+            $statement->bindValue(is_int($key) ? $key + 1 : $key, $parameter);
         }
 
         $result = $statement->executeQuery();
@@ -86,7 +89,6 @@ CODE_SAMPLE
         }
 
         $nodeFinder = new NodeFinder();
-
         $hasChanged = false;
         $objectType = new ObjectType(DoctrineClass::DBAL_STATEMENT);
         foreach ($node->stmts as $key => $stmt) {
@@ -134,14 +136,21 @@ CODE_SAMPLE
 
     private function createBindValueForeach(Expr $statementExpr, Expr $stmtsExpr): Foreach_
     {
-        $positionVariable = new Variable('position');
+        $keyVariable = new Variable('key');
         $parameterVariable = new Variable('parameter');
 
         $foreach = new Foreach_($stmtsExpr, $parameterVariable, [
-            'keyVar' => $positionVariable,
+            'keyVar' => $keyVariable,
         ]);
+
+        $ternary = new Ternary(
+            new FuncCall(new Name('is_int'), [new Arg($keyVariable)]),
+            new Plus($keyVariable, new Int_(1)),
+            $keyVariable
+        );
+
         $bindValueMethodCall = new MethodCall($statementExpr, 'bindValue', [
-            new Arg(new Plus($positionVariable, new Int_(1))),
+            new Arg($ternary),
             new Arg($parameterVariable),
         ]);
 


### PR DESCRIPTION
Fixes a bug when the array of params has string keys