### PR TITLE
[QA] Add StructArmed to QA

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -36,6 +36,10 @@ jobs:
                         name: 'PHPStan'
                         run: vendor/bin/phpstan
 
+                    -
+                        name: 'Run StructArmed'
+                        run: vendor/bin/structarmed analyze
+
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest
         timeout-minutes: 5

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "symfony/yaml": "^7.4|8.0.*"
     },
     "require-dev": {
+        "boundwize/structarmed": "^0.7.12",
         "doctrine/doctrine-bundle": "^2.18|^3.0",
         "doctrine/orm": "^2.20|^3.0",
         "phpecs/phpecs": "^2.2",

--- a/rules/TypedCollections/Rector/ClassMethod/RemoveNewArrayCollectionOutsideConstructorRector.php
+++ b/rules/TypedCollections/Rector/ClassMethod/RemoveNewArrayCollectionOutsideConstructorRector.php
@@ -101,7 +101,6 @@ CODE_SAMPLE
                 continue;
             }
 
-            /** @var Assign $assign */
             $assign = $stmt->expr;
 
             // we only care about initialization

--- a/src/Set/DoctrineSetList.php
+++ b/src/Set/DoctrineSetList.php
@@ -91,5 +91,5 @@ final class DoctrineSetList
 
     public const string GEDMO_ANNOTATIONS_TO_ATTRIBUTES = __DIR__ . '/../../config/sets/attributes/gedmo.php';
 
-    public const string MONGODB__ANNOTATIONS_TO_ATTRIBUTES = __DIR__ . '/../../config/sets/attributes/mongodb.php';
+    public const string MONGODB_ANNOTATIONS_TO_ATTRIBUTES = __DIR__ . '/../../config/sets/attributes/mongodb.php';
 }

--- a/structarmed.php
+++ b/structarmed.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Preset\Preset;
+
+return Architecture::define()
+    ->withPresets(Preset::PSR1(), Preset::PSR4());


### PR DESCRIPTION
Similar to PR on rector-src:

- https://github.com/rectorphp/rector-src/pull/7989

This PR also adds StructArmed to github workflow static analysis for QA.

This PR uses the PSR1 + PSR4 preset, and already found violation of double underscored `__` in class constant that fixed in this PR.