### PR TITLE
[NodeAnalyzer] Detect Doctrine static function mapping (loadMetadata) entity in DoctrineEntityDetector

### DIFF
--- a/rules/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector.php
+++ b/rules/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector.php
@@ -69,6 +69,9 @@ final class CastDoctrineExprToStringRector extends AbstractRector
         return [MethodCall::class];
     }
 
+    /**
+     * @param MethodCall $node
+     */
     public function refactor(Node $node): ?Node
     {
         if (! $this->isObjectType($node->var, new ObjectType(DoctrineClass::QUERY_EXPR))) {

--- a/rules/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector.php
+++ b/rules/Orm30/Rector/MethodCall/CastDoctrineExprToStringRector.php
@@ -71,10 +71,6 @@ final class CastDoctrineExprToStringRector extends AbstractRector
 
     public function refactor(Node $node): ?Node
     {
-        if (! $node instanceof MethodCall) {
-            return null;
-        }
-
         if (! $this->isObjectType($node->var, new ObjectType(DoctrineClass::QUERY_EXPR))) {
             return null;
         }

--- a/src/NodeAnalyzer/DoctrineEntityDetector.php
+++ b/src/NodeAnalyzer/DoctrineEntityDetector.php
@@ -6,6 +6,7 @@ namespace Rector\Doctrine\NodeAnalyzer;
 
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\NodeAnalyzer\DoctrineEntityAnalyzer;
 
@@ -22,7 +23,13 @@ final readonly class DoctrineEntityDetector
 
     public function detect(Class_ $class): bool
     {
-        // A. check annotations
+        // A. check static function mapping, fields are mapped in loadMetadata() method
+        // @see https://www.doctrine-project.org/projects/doctrine-orm/en/3.6/reference/php-mapping.html#static-function
+        if ($class->getMethod('loadMetadata') instanceof ClassMethod) {
+            return true;
+        }
+
+        // B. check annotations
         if ($this->doctrineEntityAnalyzer->hasClassAnnotation($class)) {
             return true;
         }
@@ -33,7 +40,7 @@ final readonly class DoctrineEntityDetector
 
         $className = $class->namespacedName->toString();
 
-        // B. check attributes
+        // C. check attributes
         $classReflection = $this->reflectionProvider->getClass($className);
 
         return $this->doctrineEntityAnalyzer->hasClassReflectionAttribute($classReflection);

--- a/tests/NodeAnalyzer/DoctrineEntityDetector/DoctrineEntityDetectorTest.php
+++ b/tests/NodeAnalyzer/DoctrineEntityDetector/DoctrineEntityDetectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\NodeAnalyzer\DoctrineEntityDetector;
+
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Doctrine\NodeAnalyzer\DoctrineEntityDetector;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+
+final class DoctrineEntityDetectorTest extends AbstractLazyTestCase
+{
+    private DoctrineEntityDetector $doctrineEntityDetector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->doctrineEntityDetector = $this->make(DoctrineEntityDetector::class);
+    }
+
+    public function testDetectStaticFunctionMapping(): void
+    {
+        $class = new Class_('SomeEntity');
+        $class->stmts[] = new ClassMethod('loadMetadata');
+
+        $this->assertTrue($this->doctrineEntityDetector->detect($class));
+    }
+}


### PR DESCRIPTION
Recognize Doctrine [static function mapping](https://www.doctrine-project.org/projects/doctrine-orm/en/3.6/reference/php-mapping.html#static-function) classes as entities in `DoctrineEntityDetector`.

Such classes map their fields in a `loadMetadata()` method instead of attributes/annotations, so the existing annotation + attribute detection misses them. The detector now also treats a class defining a `loadMetadata()` method as a Doctrine entity. The cheap, pure-AST check runs first.

## Example

```php
use Doctrine\ORM\Mapping\ClassMetadata;

final class Product
{
    private $name;

    public static function loadMetadata(ClassMetadata $metadata): void
    {
        $metadata->mapField([
            'fieldName' => 'name',
            'type' => 'string',
        ]);
    }
}
```

`Product` is a Doctrine entity even without any annotation or attribute, so `DoctrineEntityDetector::detect()` now returns `true` for it.

Mirrors rectorphp/rector-src#8059, which skips such classes in `TypedPropertyFromAssignsRector` and `RemoveUnusedPrivatePropertyRector`.
