### PR TITLE
Bump to PHP 8.4

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -50,7 +50,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.3
+                    php-version: 8.4
                     coverage: none
 
             -   uses: "ramsey/composer-install@v2"

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -23,7 +23,7 @@ jobs:
             -
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.3
+                    php-version: 8.4
                     coverage: none
 
             -   uses: "ramsey/composer-install@v2"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "description": "Rector upgrades rules for Doctrine",
     "require": {
-        "php": ">=8.3",
+        "php": ">=8.4",
         "symfony/yaml": "^7.4|8.0.*"
     },
     "require-dev": {

--- a/rules/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector.php
+++ b/rules/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\Bundle210\Rector\Class_;
 
-use PhpParser\Node\Name;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
@@ -12,6 +11,7 @@ use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -206,7 +206,7 @@ CODE_SAMPLE
 
     private function hasImplements(Class_ $class, string $interfaceFQN): bool
     {
-        return array_any($class->implements, fn(Name $name): bool => $this->isName($name, $interfaceFQN));
+        return array_any($class->implements, fn (Name $name): bool => $this->isName($name, $interfaceFQN));
     }
 
     /**

--- a/rules/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector.php
+++ b/rules/Bundle210/Rector/Class_/EventSubscriberInterfaceToAttributeRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\Bundle210\Rector\Class_;
 
+use PhpParser\Node\Name;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
@@ -205,13 +206,7 @@ CODE_SAMPLE
 
     private function hasImplements(Class_ $class, string $interfaceFQN): bool
     {
-        foreach ($class->implements as $implement) {
-            if ($this->isName($implement, $interfaceFQN)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($class->implements, fn(Name $name): bool => $this->isName($name, $interfaceFQN));
     }
 
     /**

--- a/rules/CodeQuality/Enum/DoctrineClass.php
+++ b/rules/CodeQuality/Enum/DoctrineClass.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\CodeQuality\Enum;
 
+use Deprecated;
+
 /**
  * @deprecated Switch to @see \Rector\Doctrine\Enum\DoctrineClass instead
  * @api
  */
 final readonly class DoctrineClass
 {
-    /**
-     * @deprecated BC only
-     */
+    #[Deprecated(message: 'BC only')]
     public const string COLLECTION = \Rector\Doctrine\Enum\DoctrineClass::COLLECTION;
 }

--- a/rules/TypedCollections/DocBlockProcessor/UnionCollectionTagValueNodeNarrower.php
+++ b/rules/TypedCollections/DocBlockProcessor/UnionCollectionTagValueNodeNarrower.php
@@ -176,13 +176,7 @@ final class UnionCollectionTagValueNodeNarrower
 
     private function hasCollectionDocblockType(UnionTypeNode|IntersectionTypeNode $complexTypeNode): bool
     {
-        foreach ($complexTypeNode->types as $singleType) {
-            if ($this->isCollectionIdentifierTypeNode($singleType)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($complexTypeNode->types, fn(TypeNode $typeNode): bool => $this->isCollectionIdentifierTypeNode($typeNode));
     }
 
     private function processNullableTypeNode(

--- a/rules/TypedCollections/DocBlockProcessor/UnionCollectionTagValueNodeNarrower.php
+++ b/rules/TypedCollections/DocBlockProcessor/UnionCollectionTagValueNodeNarrower.php
@@ -176,7 +176,10 @@ final class UnionCollectionTagValueNodeNarrower
 
     private function hasCollectionDocblockType(UnionTypeNode|IntersectionTypeNode $complexTypeNode): bool
     {
-        return array_any($complexTypeNode->types, fn(TypeNode $typeNode): bool => $this->isCollectionIdentifierTypeNode($typeNode));
+        return array_any(
+            $complexTypeNode->types,
+            fn (TypeNode $typeNode): bool => $this->isCollectionIdentifierTypeNode($typeNode)
+        );
     }
 
     private function processNullableTypeNode(

--- a/rules/TypedCollections/Rector/ClassMethod/NarrowReturnUnionToCollectionRector.php
+++ b/rules/TypedCollections/Rector/ClassMethod/NarrowReturnUnionToCollectionRector.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\TypedCollections\Rector\ClassMethod;
 
+use PhpParser\Node\Identifier;
+use PhpParser\Node\IntersectionType;
+use PhpParser\Node\Name;
 use PhpParser\Node;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -162,12 +165,6 @@ CODE_SAMPLE
 
     private function hasNativeReturnCollectionType(UnionType $unionType): bool
     {
-        foreach ($unionType->types as $unionedType) {
-            if ($this->isName($unionedType, DoctrineClass::COLLECTION)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($unionType->types, fn(Identifier|IntersectionType|Name $unionedType): bool => $this->isName($unionedType, DoctrineClass::COLLECTION));
     }
 }

--- a/rules/TypedCollections/Rector/ClassMethod/NarrowReturnUnionToCollectionRector.php
+++ b/rules/TypedCollections/Rector/ClassMethod/NarrowReturnUnionToCollectionRector.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\TypedCollections\Rector\ClassMethod;
 
+use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\IntersectionType;
 use PhpParser\Node\Name;
-use PhpParser\Node;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\UnionType;
@@ -165,6 +165,9 @@ CODE_SAMPLE
 
     private function hasNativeReturnCollectionType(UnionType $unionType): bool
     {
-        return array_any($unionType->types, fn(Identifier|IntersectionType|Name $unionedType): bool => $this->isName($unionedType, DoctrineClass::COLLECTION));
+        return array_any(
+            $unionType->types,
+            fn (Identifier|IntersectionType|Name $unionedType): bool => $this->isName($unionedType, DoctrineClass::COLLECTION)
+        );
     }
 }

--- a/src/PhpDocParser/DoctrineDocBlockResolver.php
+++ b/src/PhpDocParser/DoctrineDocBlockResolver.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Rector\Doctrine\PhpDocParser;
 
 use Deprecated;
-use Rector\Doctrine\TypedCollections\NodeAnalyzer\EntityLikeClassDetector;
 use PhpParser\Node\Stmt\Class_;
 use Rector\Doctrine\Enum\MappingClass;
 use Rector\Doctrine\Enum\OdmMappingClass;
 use Rector\Doctrine\NodeAnalyzer\AttrinationFinder;
+use Rector\Doctrine\TypedCollections\NodeAnalyzer\EntityLikeClassDetector;
 
 /**
  * @api

--- a/src/PhpDocParser/DoctrineDocBlockResolver.php
+++ b/src/PhpDocParser/DoctrineDocBlockResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\PhpDocParser;
 
+use Deprecated;
+use Rector\Doctrine\TypedCollections\NodeAnalyzer\EntityLikeClassDetector;
 use PhpParser\Node\Stmt\Class_;
 use Rector\Doctrine\Enum\MappingClass;
 use Rector\Doctrine\Enum\OdmMappingClass;
@@ -20,9 +22,7 @@ final readonly class DoctrineDocBlockResolver
     ) {
     }
 
-    /**
-     * @deprecated Use \Rector\Doctrine\TypedCollections\NodeAnalyzer\EntityLikeClassDetector::detect() instead
-     */
+    #[Deprecated(message: 'Use ' . EntityLikeClassDetector::class . '::detect() instead')]
     public function isDoctrineEntityClass(Class_ $class): bool
     {
         return $this->attrinationFinder->hasByMany($class, [

--- a/src/Set/DoctrineSetList.php
+++ b/src/Set/DoctrineSetList.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\Set;
 
+use Deprecated;
+
 /**
  * @api
  */
@@ -17,74 +19,46 @@ final class DoctrineSetList
 
     public const string YAML_TO_ANNOTATIONS = __DIR__ . '/../../config/yaml-to-annotations.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_COMMON_20 = __DIR__ . '/../../config/sets/doctrine-common-20.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_COLLECTION_22 = __DIR__ . '/../../config/sets/doctrine-collection-22.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_DBAL_211 = __DIR__ . '/../../config/sets/doctrine-dbal-211.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_DBAL_30 = __DIR__ . '/../../config/sets/doctrine-dbal-30.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_DBAL_38 = __DIR__ . '/../../config/sets/doctrine-dbal-38.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_DBAL_40 = __DIR__ . '/../../config/sets/doctrine-dbal-40.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_ORM_25 = __DIR__ . '/../../config/sets/doctrine-orm-25.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_ORM_28 = __DIR__ . '/../../config/sets/doctrine-orm-28.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_ORM_213 = __DIR__ . '/../../config/sets/doctrine-orm-213.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_ORM_214 = __DIR__ . '/../../config/sets/doctrine-orm-214.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_ORM_219 = __DIR__ . '/../../config/sets/doctrine-orm-219.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_ORM_300 = __DIR__ . '/../../config/sets/doctrine-orm-300.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_BUNDLE_210 = __DIR__ . '/../../config/sets/doctrine-bundle-210.php';
 
-    /**
-     * @deprecated Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets
-     */
+    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
     public const string DOCTRINE_BUNDLE_230 = __DIR__ . '/../../config/sets/doctrine-bundle-23.php';
 
     public const string ANNOTATIONS_TO_ATTRIBUTES = __DIR__ . '/../../config/sets/attributes/doctrine.php';

--- a/src/Set/DoctrineSetList.php
+++ b/src/Set/DoctrineSetList.php
@@ -19,46 +19,74 @@ final class DoctrineSetList
 
     public const string YAML_TO_ANNOTATIONS = __DIR__ . '/../../config/yaml-to-annotations.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_COMMON_20 = __DIR__ . '/../../config/sets/doctrine-common-20.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_COLLECTION_22 = __DIR__ . '/../../config/sets/doctrine-collection-22.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_DBAL_211 = __DIR__ . '/../../config/sets/doctrine-dbal-211.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_DBAL_30 = __DIR__ . '/../../config/sets/doctrine-dbal-30.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_DBAL_38 = __DIR__ . '/../../config/sets/doctrine-dbal-38.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_DBAL_40 = __DIR__ . '/../../config/sets/doctrine-dbal-40.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_ORM_25 = __DIR__ . '/../../config/sets/doctrine-orm-25.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_ORM_28 = __DIR__ . '/../../config/sets/doctrine-orm-28.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_ORM_213 = __DIR__ . '/../../config/sets/doctrine-orm-213.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_ORM_214 = __DIR__ . '/../../config/sets/doctrine-orm-214.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_ORM_219 = __DIR__ . '/../../config/sets/doctrine-orm-219.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_ORM_300 = __DIR__ . '/../../config/sets/doctrine-orm-300.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_BUNDLE_210 = __DIR__ . '/../../config/sets/doctrine-bundle-210.php';
 
-    #[Deprecated(message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets')]
+    #[Deprecated(
+        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
+    )]
     public const string DOCTRINE_BUNDLE_230 = __DIR__ . '/../../config/sets/doctrine-bundle-23.php';
 
     public const string ANNOTATIONS_TO_ATTRIBUTES = __DIR__ . '/../../config/sets/attributes/doctrine.php';

--- a/tests/NodeAnalyzer/DoctrineEntityDetector/DoctrineEntityDetectorTest.php
+++ b/tests/NodeAnalyzer/DoctrineEntityDetector/DoctrineEntityDetectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\Tests\NodeAnalyzer\DoctrineEntityDetector;
 
+use Override;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Doctrine\NodeAnalyzer\DoctrineEntityDetector;
@@ -13,6 +14,7 @@ final class DoctrineEntityDetectorTest extends AbstractLazyTestCase
 {
     private DoctrineEntityDetector $doctrineEntityDetector;
 
+    #[Override]
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
Bump minimum PHP to 8.4.

- composer.json `php` constraint `>=8.3` → `>=8.4`
- GitHub Actions `php-version` 8.3 → 8.4 (code_analysis.yaml, rector.yaml)