### PR TITLE
[DataFixtures 17] add new set for doctrine data-fixtures 17

### DIFF
--- a/config/sets/data-fixtures-17.php
+++ b/config/sets/data-fixtures-17.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Type\IntegerType;
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->ruleWithConfiguration(AddReturnTypeDeclarationRector::class, [
+        new AddReturnTypeDeclaration('Doctrine\Common\DataFixtures\OrderedFixtureInterface', 'getOrder', new IntegerType()),
+    ]);
+};

--- a/src/Set/SetProvider/DoctrineSetProvider.php
+++ b/src/Set/SetProvider/DoctrineSetProvider.php
@@ -116,6 +116,12 @@ final class DoctrineSetProvider implements SetProviderInterface
                 '1.6',
                 __DIR__ . '/../../../config/sets/data-fixtures-16.php',
             ),
+            new ComposerTriggeredSet(
+                SetGroup::DOCTRINE,
+                'doctrine/data-fixtures',
+                '1.7',
+                __DIR__ . '/../../../config/sets/data-fixtures-17.php',
+            ),
 
             new ComposerTriggeredSet(
                 SetGroup::DOCTRINE,


### PR DESCRIPTION
Doctrine data-fixtures 1.7 is the first version [requiring php 7.4+](https://github.com/doctrine/data-fixtures/blob/1.7.0/composer.json) then it's safe to add native return type from here