### PR TITLE
Remove StructArmed

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -36,10 +36,6 @@ jobs:
                         name: 'PHPStan'
                         run: vendor/bin/phpstan
 
-                    -
-                        name: 'Run StructArmed'
-                        run: vendor/bin/structarmed analyze
-
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest
         timeout-minutes: 5

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
         "symfony/yaml": "^7.4|8.0.*"
     },
     "require-dev": {
-        "boundwize/structarmed": "^0.14",
         "doctrine/doctrine-bundle": "^2.18|^3.0",
         "doctrine/orm": "^2.20|^3.0",
         "phpecs/phpecs": "^2.2",

--- a/structarmed.php
+++ b/structarmed.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-use Boundwize\StructArmed\Architecture;
-use Boundwize\StructArmed\Preset\Preset;
-
-return Architecture::define()
-    ->withPresets(Preset::PSR1(), Preset::PSR4());


### PR DESCRIPTION
Removes the `boundwize/structarmed` dev dependency, its config file, and the CI step.

## Changes

- **composer.json** — drop `boundwize/structarmed` from `require-dev`
- **structarmed.php** — delete config file
- **.github/workflows/code_analysis.yaml** — remove `Run StructArmed` step