### PR TITLE
Replace rector/type-perfect with tomasvotruba/type-coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         "rector/jack": "^0.5",
         "rector/rector-src": "dev-main",
         "rector/swiss-knife": "^2.3",
-        "rector/type-perfect": "^2.1",
         "symplify/phpstan-extensions": "^12.0",
         "symplify/phpstan-rules": "^14.9",
         "symplify/vendor-patches": "^11.5",
         "tomasvotruba/class-leak": "^2.1",
+        "tomasvotruba/type-coverage": "^2.3",
         "tracy/tracy": "^2.11"
     },
     "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,7 +27,7 @@ parameters:
         - *Source/*
         - */Fixture/*
 
-    # see https://github.com/rectorphp/type-perfect/
+    # see https://github.com/TomasVotruba/type-coverage
     type_perfect:
         no_mixed: true
         null_over_false: true


### PR DESCRIPTION
The `type-perfect` rules have moved into `tomasvotruba/type-coverage` 2.3.0, which now ships them as a bundled package:

```json
"extra": {
    "phpstan": {
        "includes": [
            "config/extension.neon",
            "packages/type-perfect/config/extension.neon"
        ]
    }
}
```

So `rector/type-perfect` is dropped and `tomasvotruba/type-coverage` added in its place.

```diff
 "require-dev": {
-    "rector/type-perfect": "^2.1",
+    "tomasvotruba/type-coverage": "^2.3",
 }
```

The `type_perfect` config key is unchanged, so `phpstan.neon` keeps its existing settings as-is - only the doc link is updated:

```diff
-    # see https://github.com/rectorphp/type-perfect/
+    # see https://github.com/TomasVotruba/type-coverage
     type_perfect:
         no_mixed: true
         null_over_false: true
         narrow_param: true
         narrow_return: true
```

The `type_coverage` rules that come along in the same package report nothing here - the codebase is already above their default 99% thresholds.