### PR TITLE
Bump dev dependencies, PHPUnit 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,21 +10,21 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.18|^3.0",
         "doctrine/orm": "^2.20|^3.0",
-        "phpecs/phpecs": "^2.2",
+        "phpecs/phpecs": "^2.3",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan": "^2.1.14",
+        "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",
-        "phpunit/phpunit": "^12.0",
-        "rector/jack": "^0.5",
+        "phpunit/phpunit": "^13.2",
+        "rector/jack": "^1.0",
         "rector/rector-src": "dev-main",
-        "rector/swiss-knife": "^2.3",
+        "rector/swiss-knife": "^2.4",
         "symplify/phpstan-extensions": "^12.0",
-        "symplify/phpstan-rules": "^14.9",
+        "symplify/phpstan-rules": "^14.12",
         "symplify/vendor-patches": "^11.5",
         "tomasvotruba/class-leak": "^2.1",
         "tomasvotruba/type-coverage": "^2.3",
-        "tracy/tracy": "^2.11"
+        "tracy/tracy": "^2.12"
     },
     "autoload": {
         "psr-4": {

--- a/rules/TypedCollections/Rector/If_/RemoveIsArrayOnCollectionRector.php
+++ b/rules/TypedCollections/Rector/If_/RemoveIsArrayOnCollectionRector.php
@@ -91,7 +91,7 @@ CODE_SAMPLE
             if ($condition instanceof FuncCall && $this->isName(
                 $condition,
                 'is_array'
-            ) && $this->collectionTypeDetector->isCollectionType($condition->getArgs()[0] ->value)) {
+            ) && $this->collectionTypeDetector->isCollectionType($condition->getArgs()[0]->value)) {
                 return $if->stmts;
             }
 

--- a/src/NodeAnalyzer/AttributeFinder.php
+++ b/src/NodeAnalyzer/AttributeFinder.php
@@ -31,7 +31,7 @@ final readonly class AttributeFinder
      * @param MappingClass::* $attributeClass
      */
     public function findAttributeByClassArgByName(
-        ClassMethod | Property | ClassLike | Param $node,
+        ClassMethod|Property|ClassLike|Param $node,
         string $attributeClass,
         string $argName
     ): ?Expr {
@@ -43,7 +43,7 @@ final readonly class AttributeFinder
      * @param string[] $argNames
      */
     public function findAttributeByClassesArgByNames(
-        ClassMethod | Property | ClassLike | Param $node,
+        ClassMethod|Property|ClassLike|Param $node,
         array $attributeClasses,
         array $argNames
     ): ?Expr {
@@ -66,7 +66,7 @@ final readonly class AttributeFinder
      * @param string[] $attributeClasses
      */
     public function findAttributeByClassesArgByName(
-        ClassMethod | Property | ClassLike | Param $node,
+        ClassMethod|Property|ClassLike|Param $node,
         array $attributeClasses,
         string $argName
     ): ?Expr {
@@ -79,7 +79,7 @@ final readonly class AttributeFinder
     }
 
     public function findAttributeByClass(
-        ClassMethod | Property | ClassLike | Param $node,
+        ClassMethod|Property|ClassLike|Param $node,
         string $attributeClass
     ): ?Attribute {
         /** @var AttributeGroup $attrGroup */
@@ -102,7 +102,7 @@ final readonly class AttributeFinder
      * @return Attribute[]
      */
     public function findManyByClass(
-        ClassMethod | Property | ClassLike | Param $node,
+        ClassMethod|Property|ClassLike|Param $node,
         string $attributeClass
     ): array {
         $attributes = [];
@@ -127,7 +127,7 @@ final readonly class AttributeFinder
      * @param string[] $attributeClasses
      */
     public function findAttributeByClasses(
-        ClassMethod | Property | ClassLike | Param $node,
+        ClassMethod|Property|ClassLike|Param $node,
         array $attributeClasses
     ): ?Attribute {
         foreach ($attributeClasses as $attributeClass) {
@@ -144,7 +144,7 @@ final readonly class AttributeFinder
      * @param string[] $attributeClasses
      */
     public function hasAttributeByClasses(
-        ClassMethod | Property | ClassLike | Param $node,
+        ClassMethod|Property|ClassLike|Param $node,
         array $attributeClasses
     ): bool {
         return $this->findAttributeByClasses($node, $attributeClasses) instanceof Attribute;

--- a/src/NodeAnalyzer/AttrinationFinder.php
+++ b/src/NodeAnalyzer/AttrinationFinder.php
@@ -87,7 +87,7 @@ final readonly class AttrinationFinder
     /**
      * @param string[] $classNames
      */
-    public function hasByMany(Class_ | Property $property, array $classNames): bool
+    public function hasByMany(Class_|Property $property, array $classNames): bool
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($property);
         if ($phpDocInfo instanceof PhpDocInfo && $phpDocInfo->hasByAnnotationClasses($classNames)) {
@@ -102,7 +102,7 @@ final readonly class AttrinationFinder
      * @param string[] $classNames
      */
     public function getByMany(
-        Class_ | Property $property,
+        Class_|Property $property,
         array $classNames
     ): DoctrineAnnotationTagValueNode|Attribute|null {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNode($property);


### PR DESCRIPTION
`composer update` + `vendor/bin/jack raise-to-installed`, with PHPUnit taken to 13.

```diff
 "require-dev": {
-    "phpecs/phpecs": "^2.2",
+    "phpecs/phpecs": "^2.3",
-    "phpstan/phpstan": "^2.1.14",
+    "phpstan/phpstan": "^2.2",
-    "phpunit/phpunit": "^12.0",
+    "phpunit/phpunit": "^13.2",
-    "rector/jack": "^0.5",
+    "rector/jack": "^1.0",
-    "rector/swiss-knife": "^2.3",
+    "rector/swiss-knife": "^2.4",
-    "symplify/phpstan-rules": "^14.9",
+    "symplify/phpstan-rules": "^14.12",
-    "tracy/tracy": "^2.11"
+    "tracy/tracy": "^2.12"
 }
```

`doctrine/doctrine-bundle` and `doctrine/orm` were left at `^2.x|^3.0` on purpose - `jack raise-to-installed` wanted to narrow them to `^3.0`, which would drop the Doctrine 2 test coverage.

PHPUnit 13 pulls `sebastian/diff` 9, which needs rector-src `04b18f6` or newer (rectorphp/rector-src#8220).

The three touched PHP files are pure formatting - phpecs 2.3 tightened the union-type and array-access spacing rules:

```diff
-    ClassMethod | Property | ClassLike | Param $node,
+    ClassMethod|Property|ClassLike|Param $node,
```