### PR TITLE
[depre] Deprecate DoctrineSetList::YAML_TO_ANNOTATIONS set

### DIFF
--- a/src/Set/DoctrineSetList.php
+++ b/src/Set/DoctrineSetList.php
@@ -17,6 +17,9 @@ final class DoctrineSetList
 
     public const string DOCTRINE_CODE_QUALITY = __DIR__ . '/../../config/sets/doctrine-code-quality.php';
 
+    #[Deprecated(
+        message: 'The YamlToAttributeDoctrineMappingRector rule this set configured was deprecated, as incomplete and prone to create buggy code. Use custom rules tailored to your YAML mapping instead'
+    )]
     public const string YAML_TO_ANNOTATIONS = __DIR__ . '/../../config/yaml-to-annotations.php';
 
     #[Deprecated(


### PR DESCRIPTION
Follow-up to #492. That PR deprecated `YamlToAttributeDoctrineMappingRector` - the only rule this set configured - so the set config is empty now and using it is a no-op.

Marks the set constant deprecated, using the same native attribute the other deprecated sets in this class use:

```php
#[Deprecated(
    message: 'The YamlToAttributeDoctrineMappingRector rule this set configured was deprecated, as incomplete and prone to create buggy code. Use custom rules tailored to your YAML mapping instead'
)]
public const string YAML_TO_ANNOTATIONS = __DIR__ . '/../../config/yaml-to-annotations.php';
```

The constant and its config file stay in place, so existing configs referencing the set keep loading - they just get a deprecation notice.