### PR TITLE
Restore CaseStringHelper as @api

### DIFF
--- a/rules/CodeQuality/Utils/CaseStringHelper.php
+++ b/rules/CodeQuality/Utils/CaseStringHelper.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\CodeQuality\Utils;
+
+use Nette\Utils\Strings;
+
+/**
+ * @api used by rector-drupal
+ */
+final class CaseStringHelper
+{
+    public static function camelCase(string $value): string
+    {
+        $spacedValue = str_replace('_', ' ', $value);
+
+        $uppercasedWords = ucwords($spacedValue);
+        $spacelessWords = str_replace(' ', '', $uppercasedWords);
+
+        $lowercasedValue = lcfirst($spacelessWords);
+        return Strings::replace($lowercasedValue, '#\W#', '');
+    }
+}

--- a/tests/CodeQuality/Utils/CaseStringHelperTest.php
+++ b/tests/CodeQuality/Utils/CaseStringHelperTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\CodeQuality\Utils;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Rector\Doctrine\CodeQuality\Utils\CaseStringHelper;
+
+final class CaseStringHelperTest extends TestCase
+{
+    #[DataProvider('provideData')]
+    public function testCamelCase(string $value, string $expectedValue): void
+    {
+        $this->assertSame($expectedValue, CaseStringHelper::camelCase($value));
+    }
+
+    /**
+     * @return Iterator<array{string, string}>
+     */
+    public static function provideData(): Iterator
+    {
+        yield ['some_property', 'someProperty'];
+        yield ['someProperty', 'someProperty'];
+        yield ['some property', 'someProperty'];
+        yield ['some-property', 'someproperty'];
+    }
+}


### PR DESCRIPTION
`CaseStringHelper` was removed in #492 along with `YamlToAttributeDoctrineMappingRector`, but it is still used downstream by `rector-drupal`.

Restored as-is and marked `@api`, so `class-leak` skips it despite having no in-repo usage:

```php
/**
 * @api used by rector-drupal
 */
final class CaseStringHelper
{
    public static function camelCase(string $value): string
    // ...
}
```

Covered with a unit test that pins current behavior:

```php
yield ['some_property', 'someProperty'];
yield ['someProperty', 'someProperty'];
yield ['some property', 'someProperty'];
yield ['some-property', 'someproperty'];
```