### PR TITLE
[ORM-350] add replace deprecated function

### DIFF
--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -303,6 +303,14 @@ return static function (RectorConfig $rectorConfig): void {
         // @see https://github.com/doctrine/orm/pull/9906
         'Doctrine\ORM\Event\LifecycleEventArgs' => 'Doctrine\Persistence\Event\LifecycleEventArgs',
     ], 'doctrine/orm', '>=2.13');
+
+    // doctrine/orm 3.5
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
+        // @see https://github.com/doctrine/orm/pull/12022
+        new MethodCallRename('Doctrine\ORM\ORMSetup', 'createAttributeMetadataConfiguration', 'createAttributeMetadataConfig'),
+        new MethodCallRename('Doctrine\ORM\ORMSetup', 'createXMLMetadataConfiguration', 'createXMLMetadataConfig'),
+        new MethodCallRename('Doctrine\ORM\ORMSetup', 'createConfiguration', 'createConfig'),
+    ], 'doctrine/orm', '>=3.5');
     $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameMethodRector::class, [
         // @see https://github.com/doctrine/orm/pull/9876
         new MethodCallRename('Doctrine\ORM\Event\LifecycleEventArgs', 'getEntityManager', 'getObjectManager'),

--- a/tests/ComposerBased/Fixture/version_bound_orm_setup_renames.php.inc
+++ b/tests/ComposerBased/Fixture/version_bound_orm_setup_renames.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Doctrine\Tests\ComposerBased\Fixture;
+
+use Doctrine\ORM\ORMSetup;
+
+final class VersionBoundOrmSetupRenames
+{
+    public function run(array $paths)
+    {
+        $attributeConfig = ORMSetup::createAttributeMetadataConfiguration($paths);
+        $xmlConfig = ORMSetup::createXMLMetadataConfiguration($paths);
+        $config = ORMSetup::createConfiguration();
+
+        return [$attributeConfig, $xmlConfig, $config];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\ComposerBased\Fixture;
+
+use Doctrine\ORM\ORMSetup;
+
+final class VersionBoundOrmSetupRenames
+{
+    public function run(array $paths)
+    {
+        $attributeConfig = ORMSetup::createAttributeMetadataConfig($paths);
+        $xmlConfig = ORMSetup::createXMLMetadataConfig($paths);
+        $config = ORMSetup::createConfig();
+
+        return [$attributeConfig, $xmlConfig, $config];
+    }
+}
+
+?>


### PR DESCRIPTION
Q: Are we allowed to have `PHP_VERSION_ID` checks or should this be part of doctrine-orm-400.php as it will be moved there for sure see: https://github.com/doctrine/orm/blob/3.6.x/UPGRADE.md#deprecate-not-using-native-lazy-objects-on-php-84