### PR TITLE
[composer-based] Bond data-fixtures rule and annotation-to-attribute sets to composer package constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
         "symfony/yaml": "^7.4|8.0.*"
     },
     "require-dev": {
-        "doctrine/data-fixtures": "^2.0",
         "doctrine/doctrine-bundle": "^2.18|^3.0",
         "doctrine/orm": "^2.20|^3.0",
         "phpecs/phpecs": "^2.3",

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "symfony/yaml": "^7.4|8.0.*"
     },
     "require-dev": {
+        "doctrine/data-fixtures": "^2.0",
         "doctrine/doctrine-bundle": "^2.18|^3.0",
         "doctrine/orm": "^2.20|^3.0",
         "phpecs/phpecs": "^2.3",

--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -15,10 +15,16 @@ use Rector\Doctrine\Dbal36\Rector\MethodCall\MigrateQueryBuilderResetQueryPartRe
 use Rector\Doctrine\Dbal40\Rector\MethodCall\ChangeCompositeExpressionAddMultipleWithWithRector;
 use Rector\Doctrine\Dbal40\Rector\StmtsAwareInterface\ExecuteQueryParamsToBindValueRector;
 use Rector\Doctrine\Dbal42\Rector\New_\AddArrayResultColumnNamesRector;
+use Rector\Doctrine\DoctrineFixture\Rector\MethodCall\AddGetReferenceTypeRector;
 use Rector\Doctrine\Orm214\Rector\Param\ReplaceLifecycleEventArgsByDedicatedEventArgsRector;
 use Rector\Doctrine\Orm28\Rector\MethodCall\IterateToToIterableRector;
 use Rector\Doctrine\Orm30\Rector\MethodCall\CastDoctrineExprToStringRector;
 use Rector\Doctrine\Orm30\Rector\MethodCall\SetParametersArrayToCollectionRector;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\Rector\Property\NestedAnnotationToAttributeRector;
+use Rector\Php80\ValueObject\AnnotationPropertyToAttributeClass;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+use Rector\Php80\ValueObject\NestedAnnotationToAttribute;
 use Rector\Removing\Rector\ClassMethod\ArgumentRemoverRector;
 use Rector\Removing\ValueObject\ArgumentRemover;
 use Rector\Renaming\Rector\Class_\RenameAttributeRector;
@@ -69,6 +75,9 @@ return static function (RectorConfig $rectorConfig): void {
         // doctrine/doctrine-bundle 2.3 and 2.8
         AddAnnotationToRepositoryRector::class,
         EventSubscriberInterfaceToAttributeRector::class,
+
+        // doctrine/data-fixtures 1.6
+        AddGetReferenceTypeRector::class,
     ]);
 
     // doctrine/data-fixtures 1.7
@@ -998,4 +1007,178 @@ return static function (RectorConfig $rectorConfig): void {
         // @see https://github.com/doctrine/dbal/blob/4.0.x/UPGRADE.md#bc-break-removed-connection_schemamanager-and-connectiongetschemamanager
         new MethodCallRename('Doctrine\DBAL\Connection', 'getSchemaManager', 'createSchemaManager'),
     ], 'doctrine/dbal', '>=4.0');
+
+    // doctrine/orm 2.9, the first version to ship mapping classes as PHP 8 attributes
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(NestedAnnotationToAttributeRector::class, [
+        /** @see https://www.doctrine-project.org/projects/doctrine-orm/en/2.13/reference/attributes-reference.html#joincolumn-inversejoincolumn */
+        new NestedAnnotationToAttribute('Doctrine\ORM\Mapping\JoinTable', [
+            new AnnotationPropertyToAttributeClass('Doctrine\ORM\Mapping\JoinColumn', 'joinColumns'),
+            new AnnotationPropertyToAttributeClass(
+                'Doctrine\ORM\Mapping\InverseJoinColumn',
+                'inverseJoinColumns',
+                true
+            ),
+        ]),
+
+        /** @see https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/annotations-reference.html#joincolumns */
+        new NestedAnnotationToAttribute('Doctrine\ORM\Mapping\JoinColumns', [
+            new AnnotationPropertyToAttributeClass('Doctrine\ORM\Mapping\JoinColumn'),
+        ], true),
+
+        new NestedAnnotationToAttribute('Doctrine\ORM\Mapping\Table', [
+            new AnnotationPropertyToAttributeClass('Doctrine\ORM\Mapping\Index', 'indexes', true),
+            new AnnotationPropertyToAttributeClass('Doctrine\ORM\Mapping\UniqueConstraint', 'uniqueConstraints', true),
+        ]),
+    ], 'doctrine/orm', '>=2.9');
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(AnnotationToAttributeRector::class, [
+        // class
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\Entity', null, ['repositoryClass']),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\Column'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\UniqueConstraint'),
+
+        // id
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\Id'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\GeneratedValue'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\SequenceGenerator'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\Index'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\CustomIdGenerator', null, ['class']),
+
+        // relations
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\OneToOne', null, ['targetEntity']),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\OneToMany', null, ['targetEntity']),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\ManyToMany', null, ['targetEntity']),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinTable'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\ManyToOne', null, ['targetEntity']),
+
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\OrderBy'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\JoinColumn'),
+
+        // embed
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\Embeddable'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\Embedded', null, ['class']),
+
+        // inheritance
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\MappedSuperclass', null, ['repositoryClass']),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\InheritanceType'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\DiscriminatorColumn'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\DiscriminatorMap'),
+
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\Version'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\ChangeTrackingPolicy'),
+
+        // events
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\HasLifecycleCallbacks'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\PostLoad'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\PostPersist'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\PostRemove'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\PostUpdate'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\PreFlush'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\PrePersist'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\PreRemove'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\PreUpdate'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\Cache'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\EntityListeners'),
+
+        // Overrides
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\AssociationOverrides'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\AssociationOverride'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\AttributeOverrides'),
+        new AnnotationToAttribute('Doctrine\ORM\Mapping\AttributeOverride'),
+    ], 'doctrine/orm', '>=2.9');
+
+    // doctrine/mongodb-odm 2.3, the first version to ship mapping classes as PHP 8 attributes
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(NestedAnnotationToAttributeRector::class, [
+        new NestedAnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\Indexes', [
+            new AnnotationPropertyToAttributeClass('Doctrine\ODM\MongoDB\Mapping\Annotations\Index'),
+            new AnnotationPropertyToAttributeClass('Doctrine\ODM\MongoDB\Mapping\Annotations\UniqueIndex'),
+        ], true),
+    ], 'doctrine/mongodb-odm', '>=2.3');
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(AnnotationToAttributeRector::class, [
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\File\ChunkSize'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\File\Filename'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\File\Length'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\File\Metadata'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\File\UploadDate'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\AlsoLoad'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\ChangeTrackingPolicy'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\DefaultDiscriminatorValue'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\DiscriminatorField'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\DiscriminatorMap'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\DiscriminatorValue'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\Document'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\EmbeddedDocument'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\EmbedMany'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\EmbedOne'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\Field'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\File'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\HasLifecycleCallbacks'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\Id'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\Index'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\InheritanceType'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\Lock'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\MappedSuperclass'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\PostLoad'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\PostPersist'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\PostRemove'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\PostUpdate'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\PreFlush'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\PreLoad'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\PrePersist'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\PreRemove'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\PreUpdate'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\QueryResultDocument'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\ReadPreference'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\ReferenceMany'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\ReferenceOne'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\ShardKey'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\UniqueIndex'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\Validation'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\Version'),
+        new AnnotationToAttribute('Doctrine\ODM\MongoDB\Mapping\Annotations\View'),
+    ], 'doctrine/mongodb-odm', '>=2.3');
+
+    // doctrine/mongodb-odm-bundle 4.4, the first version to ship the constraint as PHP 8 attribute
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(AnnotationToAttributeRector::class, [
+        new AnnotationToAttribute('Doctrine\Bundle\MongoDBBundle\Validator\Constraints\Unique'),
+    ], 'doctrine/mongodb-odm-bundle', '>=4.4');
+
+    // gedmo/doctrine-extensions 3.5, the first version to ship mapping classes as PHP 8 attributes
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(AnnotationToAttributeRector::class, [
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\Blameable'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\IpTraceable'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\Language'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\Locale'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\Loggable'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\Reference'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\ReferenceIntegrity'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\ReferenceMany'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\ReferenceManyEmbed'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\ReferenceOne'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\Slug'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\SlugHandler'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\SlugHandlerOption'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\SoftDeleteable'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\SortableGroup'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\SortablePosition'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\Timestampable'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\Translatable'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\TranslationEntity'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\Tree'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\TreeClosure'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\TreeLeft'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\TreeLevel'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\TreeLockTime'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\TreeParent'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\TreePath'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\TreePathHash'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\TreePathSource'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\TreeRight'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\TreeRoot'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\Uploadable'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\UploadableFileMimeType'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\UploadableFileName'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\UploadableFilePath'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\UploadableFileSize'),
+        new AnnotationToAttribute('Gedmo\Mapping\Annotation\Versioned'),
+    ], 'gedmo/doctrine-extensions', '>=3.5');
 };

--- a/rules-tests/DoctrineFixture/Rector/MethodCall/AddGetReferenceTypeRector/AddGetReferenceTypeRectorTest.php
+++ b/rules-tests/DoctrineFixture/Rector/MethodCall/AddGetReferenceTypeRector/AddGetReferenceTypeRectorTest.php
@@ -25,4 +25,12 @@ final class AddGetReferenceTypeRectorTest extends AbstractRectorTestCase
     {
         return __DIR__ . '/config/configured_rule.php';
     }
+
+    /**
+     * The rule is bonded to doctrine/data-fixtures, that is not installed here
+     */
+    protected function provideComposerJsonFilePath(): string
+    {
+        return __DIR__ . '/config/composer.json';
+    }
 }

--- a/rules-tests/DoctrineFixture/Rector/MethodCall/AddGetReferenceTypeRector/config/composer.json
+++ b/rules-tests/DoctrineFixture/Rector/MethodCall/AddGetReferenceTypeRector/config/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "doctrine/data-fixtures": "^1.6"
+    }
+}

--- a/rules/DoctrineFixture/Rector/MethodCall/AddGetReferenceTypeRector.php
+++ b/rules/DoctrineFixture/Rector/MethodCall/AddGetReferenceTypeRector.php
@@ -15,6 +15,8 @@ use Rector\Doctrine\DoctrineFixture\Reflection\ParameterTypeResolver;
 use Rector\Doctrine\Enum\DoctrineClass;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -23,11 +25,16 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see https://github.com/doctrine/data-fixtures/pull/409/files
  */
-final class AddGetReferenceTypeRector extends AbstractRector
+final class AddGetReferenceTypeRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly ParameterTypeResolver $parameterTypeResolver,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('doctrine/data-fixtures', '>=1.6');
     }
 
     /**

--- a/src/Set/SetProvider/DoctrineSetProvider.php
+++ b/src/Set/SetProvider/DoctrineSetProvider.php
@@ -23,13 +23,15 @@ final class DoctrineSetProvider implements SetProviderInterface
      * @var array<string, string>
      */
     private const array COMPOSER_BASED_TRIGGER_PACKAGES = [
-        'doctrine/data-fixtures' => '>=1.7',
+        'doctrine/data-fixtures' => '>=1.6',
         'doctrine/common' => '>=2.0',
         'doctrine/collections' => '>=2.2',
         'doctrine/doctrine-bundle' => '>=2.3',
         'doctrine/orm' => '>=2.5',
         'doctrine/dbal' => '>=2.11',
-        'doctrine/mongodb-odm' => '>=2.16',
+        'doctrine/mongodb-odm' => '>=2.3',
+        'doctrine/mongodb-odm-bundle' => '>=4.4',
+        'gedmo/doctrine-extensions' => '>=3.5',
     ];
 
     /**

--- a/tests/ComposerBased/Fixture/version_bound_annotation_to_attribute.php.inc
+++ b/tests/ComposerBased/Fixture/version_bound_annotation_to_attribute.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Doctrine\Tests\ComposerBased\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+final class VersionBoundAnnotationToAttribute
+{
+    /**
+     * @ORM\Column(type="string")
+     */
+    private $name;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\ComposerBased\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+final class VersionBoundAnnotationToAttribute
+{
+    #[ORM\Column(type: 'string')]
+    private $name;
+}
+
+?>


### PR DESCRIPTION
Follow-up to #495. Two gaps remained after the composer-based bonding.

## 1. `AddGetReferenceTypeRector` had no composer constraint

The rule fills the second `getReference()` argument, which only exists from **doctrine/data-fixtures 1.6** ([data-fixtures#409](https://github.com/doctrine/data-fixtures/pull/409)). The set provider already knew the version — it registers `data-fixtures-16.php` as a `ComposerTriggeredSet` at `1.6` — but the rule itself carried no `ComposerPackageConstraintInterface`, and unlike its `data-fixtures-17` sibling it was never added to `composer-based.php`.

```diff
-final class AddGetReferenceTypeRector extends AbstractRector
+final class AddGetReferenceTypeRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('doctrine/data-fixtures', '>=1.6');
+    }
```

What the rule does, now only on data-fixtures >= 1.6:

```diff
 final class SomeFixture extends AbstractFixture
 {
     public function run(SomeEntity $someEntity)
     {
-        $someEntity->setSomePassedEntity($this->getReference('some-id'));
+        $someEntity->setSomePassedEntity($this->getReference('some-id', SomePassedEntity::class));
     }
 }
```

`doctrine/data-fixtures` is added to `require-dev` so the rule test actually exercises the constraint instead of silently skipping.

## 2. Annotation-to-attribute sets are now composer-bound too

`ANNOTATIONS_TO_ATTRIBUTES`, `GEDMO_ANNOTATIONS_TO_ATTRIBUTES` and `MONGODB_ANNOTATIONS_TO_ATTRIBUTES` convert annotations to attribute classes that only exist from a specific package version. Each config block moves into `composer-based.php` bound to the version that first shipped those classes as PHP 8 attributes:

| package | version | verified against |
| --- | --- | --- |
| `doctrine/orm` | `>=2.9` | `#[Attribute]` on `Mapping\Entity` absent in 2.8.0, present in 2.9.0 |
| `doctrine/mongodb-odm` | `>=2.3` | absent in 2.2.0, present in 2.3.0 |
| `doctrine/mongodb-odm-bundle` | `>=4.4` | `Validator\Constraints\Unique` absent in 4.3.0, present in 4.4.0 |
| `gedmo/doctrine-extensions` | `>=3.5` | `Mapping\Annotation\Slug` absent in v3.4.0, present in v3.5.0 |

The `Unique` constraint previously travelled inside the MongoDB set but belongs to a different package, so it gets its own bound.

Result on an ORM >= 2.9 project using `withComposerBased()`:

```diff
 use Doctrine\ORM\Mapping as ORM;

-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 final class SomeEntity
 {
-    /**
-     * @ORM\Column(type="string")
-     */
+    #[ORM\Column(type: 'string')]
     private $name;
 }
```

The standalone set files stay in place, same as the version sets in #495 — the `DoctrineSetList` constants remain usable.

### Heads-up on scope

This makes annotation-to-attribute conversion part of `withComposerBased()` rather than an explicit opt-in set. Any project on ORM >= 2.9 and PHP 8 (`AnnotationToAttributeRector` is still gated on PHP 8.0 by its own min-version) will now get its mapping annotations rewritten to attributes. That is a deliberate migration rather than a version-compat fix, so it is worth a conscious call before merging.

### Trigger packages

`COMPOSER_BASED_TRIGGER_PACKAGES` gains `doctrine/mongodb-odm-bundle` and `gedmo/doctrine-extensions`, lowers `doctrine/mongodb-odm` to `>=2.3` and `doctrine/data-fixtures` to `>=1.6`, so the set is picked up for projects on those versions.

New `tests/ComposerBased` fixture covers the ORM annotation-to-attribute path end to end through the composer-based set.
