### PR TITLE
[SetList] Add COMPOSER_BASED constant, remove empty DOCTRINE_BUNDLE_210 set

### DIFF
--- a/config/sets/doctrine-bundle-210.php
+++ b/config/sets/doctrine-bundle-210.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-use Rector\Config\RectorConfig;
-
-return static function (RectorConfig $rectorConfig): void {
-    // only for BC
-};

--- a/src/Set/DoctrineSetList.php
+++ b/src/Set/DoctrineSetList.php
@@ -11,6 +11,8 @@ use Deprecated;
  */
 final class DoctrineSetList
 {
+    public const string COMPOSER_BASED = __DIR__ . '/../../config/sets/composer-based.php';
+
     public const string TYPED_COLLECTIONS = __DIR__ . '/../../config/sets/typed-collections.php';
 
     public const string TYPED_COLLECTIONS_DOCBLOCKS = __DIR__ . '/../../config/sets/typed-collections-docblocks.php';
@@ -81,11 +83,6 @@ final class DoctrineSetList
         message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
     )]
     public const string DOCTRINE_ORM_300 = __DIR__ . '/../../config/sets/doctrine-orm-300.php';
-
-    #[Deprecated(
-        message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'
-    )]
-    public const string DOCTRINE_BUNDLE_210 = __DIR__ . '/../../config/sets/doctrine-bundle-210.php';
 
     #[Deprecated(
         message: 'Use withComposerBased() instead, see https://getrector.com/blog/introducing-composer-version-based-sets'


### PR DESCRIPTION
Two small `DoctrineSetList` cleanups.

## Add `COMPOSER_BASED`

`config/sets/composer-based.php` had no constant, so it could only be referenced by a raw path:

```php
$rectorConfig->sets([__DIR__ . '/../../../config/sets/composer-based.php']);
```

Now:

```php
use Rector\Doctrine\Set\DoctrineSetList;

return RectorConfig::configure()
    ->withSets([
        DoctrineSetList::COMPOSER_BASED,
    ]);
```

`->withComposerBased(doctrine: true)` stays the recommended way - this is for configs that enumerate sets explicitly.

## Remove `DOCTRINE_BUNDLE_210`

`config/sets/doctrine-bundle-210.php` has been an empty closure since #382 (2025-05), when the `AsListener` attribute rule moved to the doctrine-bundle 2.8 set:

```php
return static function (RectorConfig $rectorConfig): void {
    // only for BC
};
```

It is not registered in `DoctrineSetProvider`, so it never shows up in the prepared set list - the only way to reach it was the deprecated `DoctrineSetList::DOCTRINE_BUNDLE_210` constant, which loaded a set that did nothing. File and constant removed together, same as 5f471cf.