### PR TITLE
Remove unused symfony/yaml dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "license": "MIT",
     "description": "Rector upgrades rules for Doctrine",
     "require": {
-        "php": ">=8.4",
-        "symfony/yaml": "^7.4|8.0.*"
+        "php": ">=8.4"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.18|^3.0",


### PR DESCRIPTION
`symfony/yaml` was only used by `YamlToAttributeDoctrineMappingRector`, deprecated in #492. That rule's body is now a `throw`, and the YAML parsing code it needed is gone.

There is no `Symfony\Component\Yaml` usage left anywhere in `config/`, `rules/`, `src/` or `tests/`, so the package no longer needs it in `require`:

```diff
     "require": {
-        "php": ">=8.4",
-        "symfony/yaml": "^7.4|8.0.*"
+        "php": ">=8.4"
     },
```

This drops a runtime dependency from every `rector/rector` install.