### PR TITLE
[DBAL-40] add replace for array

### DIFF
--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -984,6 +984,12 @@ return static function (RectorConfig $rectorConfig): void {
             'INTEGER'
         ),
     ], 'doctrine/dbal', '>=4.0');
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameClassConstFetchRector::class, [
+        // @see https://github.com/doctrine/dbal/blob/4.4.x/UPGRADE.md#bc-break-removed-array-and-object-column-types
+        new RenameClassAndConstFetch(
+            'Doctrine\\DBAL\\Types\\Types', 'ARRAY', 'Doctrine\\DBAL\\Types\\Types', 'SIMPLE_ARRAY'
+        ),
+    ], 'doctrine/dbal', '>=4.0');
     $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameClassRector::class, [
         // @see https://github.com/doctrine/dbal/blob/4.0.x/UPGRADE.md#bc-break-renamed-sqlite-platform-classes
         'Doctrine\DBAL\Platforms\SqlitePlatform' => 'Doctrine\DBAL\Platforms\SQLitePlatform',


### PR DESCRIPTION
I confirmed replacing the removed `ARRAY` type to `SIMPLE_ARRAY` it will not cause a database diff