### PR TITLE
Move AddAnnotationToRepositoryRector to composer-based set only

### DIFF
--- a/config/sets/doctrine-code-quality.php
+++ b/config/sets/doctrine-code-quality.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Doctrine\Bundle230\Rector\Class_\AddAnnotationToRepositoryRector;
 use Rector\Doctrine\CodeQuality\Rector\Property\CorrectDefaultTypesOnEntityPropertyRector;
 use Rector\Doctrine\CodeQuality\Rector\Property\TypedPropertyFromColumnTypeRector;
 use Rector\Doctrine\CodeQuality\Rector\Property\TypedPropertyFromToOneRelationTypeRector;
@@ -19,9 +18,6 @@ return static function (RectorConfig $rectorConfig): void {
         TypedPropertyFromColumnTypeRector::class,
         TypedPropertyFromToOneRelationTypeRector::class,
         CompleteReturnDocblockFromToManyRector::class,
-
-        // @extends annotations service repository generics
-        AddAnnotationToRepositoryRector::class,
     ]);
 
     $rectorConfig->ruleWithConfiguration(AttributeKeyToClassConstFetchRector::class, [


### PR DESCRIPTION
`AddAnnotationToRepositoryRector` already declares its own composer constraint via `ComposerPackageConstraintInterface`:

```php
public function provideComposerPackageConstraint(): ComposerPackageConstraint
{
    return new ComposerPackageConstraint('doctrine/doctrine-bundle', '>=2.3');
}
```

`2.3` is where the `ServiceEntityRepository` parent gained `@template` generics ([commit](https://github.com/doctrine/DoctrineBundle/commit/2f12b5302bafac39c70b024e1686119be28b79ab)), so `@extends<T>` is only valid from there.

It was registered in **both** the `doctrine-code-quality` set (unconditional) and the `composer-based` set (constraint-aware). This removes the duplicate from `doctrine-code-quality`, leaving it only in `composer-based` where the version bound actually applies.

Rule output unchanged:

```diff
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;

+/**
+ * @extends ServiceEntityRepository<\SomeEntity>
+ */
 final class SomeRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, SomeEntity::class);
     }
 }
```
