### PR TITLE
[ComposerBased] Pin version-bound tests to a test-specific composer.json instead of the repo root

### DIFF
--- a/tests/ComposerBased/ComposerBasedTest.php
+++ b/tests/ComposerBased/ComposerBasedTest.php
@@ -25,4 +25,10 @@ final class ComposerBasedTest extends AbstractRectorTestCase
     {
         return __DIR__ . '/config/composer_based.php';
     }
+
+    protected function provideComposerJsonFilePath(): ?string
+    {
+        // pin the version-bound rules to the versions the fixtures target, instead of the ones installed locally
+        return __DIR__ . '/composer.json';
+    }
 }

--- a/tests/ComposerBased/ComposerBasedTest.php
+++ b/tests/ComposerBased/ComposerBasedTest.php
@@ -26,7 +26,7 @@ final class ComposerBasedTest extends AbstractRectorTestCase
         return __DIR__ . '/config/composer_based.php';
     }
 
-    protected function provideComposerJsonFilePath(): ?string
+    protected function provideComposerJsonFilePath(): string
     {
         // pin the version-bound rules to the versions the fixtures target, instead of the ones installed locally
         return __DIR__ . '/composer.json';

--- a/tests/ComposerBased/composer.json
+++ b/tests/ComposerBased/composer.json
@@ -1,0 +1,6 @@
+{
+    "require": {
+        "doctrine/orm": "^3.5",
+        "doctrine/dbal": "^4.0"
+    }
+}


### PR DESCRIPTION
## Problem

`ComposerBasedTest` had no `provideComposerJsonFilePath()` override, so `InstalledPackageResolver` fell back to the **repo root** `composer.json` (`getcwd()`) to resolve the version-bound rules. The version-bound fixtures then depended on whatever `doctrine/*` happened to be installed locally, and on the root's declared ranges — not on a version the test controls.

This surfaced via rectorphp/rector-src#8363: once a distributed package resolves to its **lowest declared** version, the root `doctrine/orm: ^3.0` floor dropped the `ORMSetup >=3.5` renames and `version_bound_orm_setup_renames` broke.

## Fix

Pin the version-bound tests to a **test-specific** `composer.json`, via the existing `provideComposerJsonFilePath()` hook:

```php
protected function provideComposerJsonFilePath(): ?string
{
    return __DIR__ . '/composer.json';
}
```

```json
{
    "require": {
        "doctrine/orm": "^3.5",
        "doctrine/dbal": "^4.0"
    }
}
```

Those floors match the APIs the three fixtures target (`doctrine/orm >=3.5` for the ORMSetup renames and `>=2.9` for the annotation-to-attribute pass, `doctrine/dbal >=4.0` for the `getSchemaManager`/`isFullfilledBy` renames). The root `composer.json` no longer influences the result.

This path (`composerJsonFilePath` set) resolves versions straight from the declared constraints, so it is independent of rector-src#8363 and green on the current released `rector-src` as well — verified locally, 3/3.