### PR TITLE
[ComposerBased] Bump doctrine/orm floor to ^3.5 so version-bound ORMSetup renames stay active

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^3.0",
-        "doctrine/orm": "^3.0",
+        "doctrine/orm": "^3.5",
         "symplify/easy-coding-standard": "^13.2",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.2",

--- a/tests/ComposerBased/ComposerBasedTest.php
+++ b/tests/ComposerBased/ComposerBasedTest.php
@@ -25,10 +25,4 @@ final class ComposerBasedTest extends AbstractRectorTestCase
     {
         return __DIR__ . '/config/composer_based.php';
     }
-
-    protected function provideComposerJsonFilePath(): string
-    {
-        // pin the version-bound rules to the versions the fixtures target, instead of the ones installed locally
-        return __DIR__ . '/composer.json';
-    }
 }

--- a/tests/ComposerBased/composer.json
+++ b/tests/ComposerBased/composer.json
@@ -1,6 +1,0 @@
-{
-    "require": {
-        "doctrine/orm": "^3.5",
-        "doctrine/dbal": "^4.0"
-    }
-}


### PR DESCRIPTION
Follow-up to #513, which did not actually fix the `ComposerBased` version resolution.

## Why #513 did not work

`RectorConfig::ruleWithConfigurationComposerVersionBound()` resolves the package version through its own `new InstalledPackageResolver()` (no project dir, no composer.json path) at config-build time, reading the **repo root** `composer.json` + `installed.json`. It never consults the `provideComposerJsonFilePath()` singleton, so the test-specific `tests/ComposerBased/composer.json` added in #513 had no effect on the version-bound renames.

## Root cause

The version-bound renames are gated on the **root** `doctrine/orm` constraint. rector-src [#8363](https://github.com/rectorphp/rector-src/pull/8363) makes a distributed package (`"type": "rector-extension"`) target the **lowest** declared version, so the root `doctrine/orm: ^3.0` dropped the resolved version to `3.0`, deactivating the `ORMSetup ... >=3.5` renames — `version_bound_orm_setup_renames` then stopped changing.

## Fix

Declare the orm floor this extension actually targets:

```diff
-        "doctrine/orm": "^3.0",
+        "doctrine/orm": "^3.5",
```

The lowest declared version is now `3.5`, the `>=3.5` renames stay active, and the `version_bound_orm_setup_renames` fixture is unchanged. Also removes the ineffective `provideComposerJsonFilePath()` override and `tests/ComposerBased/composer.json` from #513.

Verified locally against rector-src#8363: 3/3 green, fixtures untouched.
