### PR TITLE
Remove illuminate/container patch scaffolding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "rector/rector-src": "dev-main",
         "rector/swiss-knife": "^2.4",
         "symplify/phpstan-rules": "^14.12",
-        "symplify/vendor-patches": "^11.5",
         "tomasvotruba/class-leak": "^2.1.8",
         "tomasvotruba/type-coverage": "^2.3",
         "tracy/tracy": "^2.12"
@@ -46,15 +45,11 @@
         "check-cs": "vendor/bin/ecs check --ansi",
         "fix-cs": "vendor/bin/ecs check --fix --ansi"
     },
-    "extra": {
-        "enable-patching": true
-    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "cweagans/composer-patches": true,
             "rector/extension-installer": true,
             "phpstan/extension-installer": true
         }


### PR DESCRIPTION
`rector/rector-src` switched its DI container from `illuminate/container` to [`entropy/entropy`](https://github.com/TomasVotruba/entropy) (rectorphp/rector-src#8362), so the Illuminate container patch it used to declare is gone.

This drops the now-dead patch opt-in that this package carried only to apply that upstream patch:

```diff
     "require-dev": {
-        "symplify/vendor-patches": "^11.5",
     },
-    "extra": {
-        "enable-patching": true
-    },
     "config": {
         "allow-plugins": {
-            "cweagans/composer-patches": true,
         }
     }
```

No patch is declared in this repo and none remains upstream, so the scaffolding is pure dead weight.

> [!NOTE]
> Green CI here depends on rectorphp/rector-src#8362 being merged first — this package tracks `rector/rector-src: dev-main`, which still ships the (now unpatched) Illuminate container until that PR lands.
