### PR TITLE
[DBAL 32] add platform get name replace

### DIFF
--- a/config/sets/composer-based.php
+++ b/config/sets/composer-based.php
@@ -12,6 +12,7 @@ use Rector\Doctrine\Collection22\Rector\CriteriaOrderingConstantsDeprecationRect
 use Rector\Doctrine\Dbal211\Rector\MethodCall\ExtractArrayArgOnQueryBuilderSelectRector;
 use Rector\Doctrine\Dbal211\Rector\MethodCall\ReplaceFetchAllMethodCallRector;
 use Rector\Doctrine\Dbal31\Rector\MethodCall\QueryBuilderExecuteToExecuteQueryOrExecuteStatementRector;
+use Rector\Doctrine\Dbal32\Rector\Identical\PlatformGetNameToInstanceofRector;
 use Rector\Doctrine\Dbal36\Rector\MethodCall\MigrateQueryBuilderResetQueryPartRector;
 use Rector\Doctrine\Dbal40\Rector\MethodCall\ChangeCompositeExpressionAddMultipleWithWithRector;
 use Rector\Doctrine\Dbal40\Rector\StmtsAwareInterface\ExecuteQueryParamsToBindValueRector;
@@ -70,6 +71,9 @@ return static function (RectorConfig $rectorConfig): void {
 
         // doctrine/dbal 3.1
         QueryBuilderExecuteToExecuteQueryOrExecuteStatementRector::class,
+
+        // doctrine/dbal 3.2
+        PlatformGetNameToInstanceofRector::class,
 
         // doctrine/dbal 4.0 and 4.2
         ChangeCompositeExpressionAddMultipleWithWithRector::class,

--- a/rules-tests/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector/Fixture/replace.php.inc
+++ b/rules-tests/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector/Fixture/replace.php.inc
@@ -1,0 +1,62 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Dbal32\Rector\Identical\PlatformGetNameToInstanceofRector;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+class TestMigration
+{
+    /** @var AbstractPlatform */
+    public $platform;
+
+    public function run(): void
+    {
+        if ('postgresql' === $this->platform->getName()) {
+            echo "Is Postgres";
+        }
+
+        if ($this->platform->getName() === 'postgresql') {
+            echo "Is Postgres";
+        }
+
+        if ($this->platform->getName() === 'mysql') {
+            echo "Is MySQL";
+        }
+
+        if ($this->platform->getName() === 'unknown_db') {
+            echo "Is Unknown";
+        }
+    }
+}
+
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Dbal32\Rector\Identical\PlatformGetNameToInstanceofRector;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+class TestMigration
+{
+    /** @var AbstractPlatform */
+    public $platform;
+
+    public function run(): void
+    {
+        if ($this->platform instanceof \Doctrine\DBAL\Platforms\PostgreSQLPlatform) {
+            echo "Is Postgres";
+        }
+
+        if ($this->platform instanceof \Doctrine\DBAL\Platforms\PostgreSQLPlatform) {
+            echo "Is Postgres";
+        }
+
+        if ($this->platform instanceof \Doctrine\DBAL\Platforms\MySQLPlatform) {
+            echo "Is MySQL";
+        }
+
+        if ($this->platform->getName() === 'unknown_db') {
+            echo "Is Unknown";
+        }
+    }
+}

--- a/rules-tests/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector/Fixture/replace.php.inc
+++ b/rules-tests/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector/Fixture/replace.php.inc
@@ -23,6 +23,22 @@ class TestMigration
             echo "Is MySQL";
         }
 
+        if ($this->platform->getName() === 'sqlite') {
+            echo "Is SQLite";
+        }
+
+        if ($this->platform->getName() === 'oracle') {
+            echo "Is Oracle";
+        }
+
+        if ($this->platform->getName() === 'mssql') {
+            echo "Is SQL Server";
+        }
+
+        if ($this->platform->getName() === 'db2') {
+            echo "Is DB2";
+        }
+
         if ($this->platform->getName() === 'unknown_db') {
             echo "Is Unknown";
         }
@@ -53,6 +69,22 @@ class TestMigration
 
         if ($this->platform instanceof \Doctrine\DBAL\Platforms\MySQLPlatform) {
             echo "Is MySQL";
+        }
+
+        if ($this->platform instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {
+            echo "Is SQLite";
+        }
+
+        if ($this->platform instanceof \Doctrine\DBAL\Platforms\OraclePlatform) {
+            echo "Is Oracle";
+        }
+
+        if ($this->platform instanceof \Doctrine\DBAL\Platforms\SQLServerPlatform) {
+            echo "Is SQL Server";
+        }
+
+        if ($this->platform instanceof \Doctrine\DBAL\Platforms\DB2Platform) {
+            echo "Is DB2";
         }
 
         if ($this->platform->getName() === 'unknown_db') {

--- a/rules-tests/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector/Fixture/skip.php.inc
+++ b/rules-tests/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector/Fixture/skip.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Dbal32\Rector\Identical\PlatformGetNameToInstanceofRector;
+
+class SkipTest
+{
+    public function run($someObject): void
+    {
+        // Skip: Not a method call (comparing string to standard variable)
+        if ('postgresql' === $someObject) {
+            return;
+        }
+
+        // Skip: Method name is not getName()
+        if ('postgresql' === $someObject->getDatabaseType()) {
+            return;
+        }
+
+        // Skip: Unknown/custom platform string not in PLATFORM_MAP
+        if ($someObject->getName() === 'postgresql') {
+            return;
+        }
+        if ('postgresql' === $someObject->getName()) {
+            return;
+        }
+
+        // Skip: Comparing getName() result to an integer or non-string
+        if (123 === $someObject->getName()) {
+            return;
+        }
+    }
+}

--- a/rules-tests/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector/PlatformGetNameToInstanceofRectorTest.php
+++ b/rules-tests/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector/PlatformGetNameToInstanceofRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Dbal32\Rector\Identical\PlatformGetNameToInstanceofRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class PlatformGetNameToInstanceofRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector/config/configured_rule.php
+++ b/rules-tests/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\Dbal32\Rector\Identical\PlatformGetNameToInstanceofRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(PlatformGetNameToInstanceofRector::class);
+};

--- a/rules/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector.php
+++ b/rules/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector.php
@@ -24,19 +24,24 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class PlatformGetNameToInstanceofRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    /**
+     * Maps the string returned by AbstractPlatform::getName() to its platform class.
+     *
+     * @var array<string, string>
+     */
     private const array PLATFORM_MAP = [
-            'postgresql' => 'Doctrine\DBAL\Platforms\PostgreSQLPlatform',
-            'mysql' => 'Doctrine\DBAL\Platforms\MySQLPlatform',
-            'sqlite' => 'Doctrine\DBAL\Platforms\SqlitePlatform',
-            'oracle' => 'Doctrine\DBAL\Platforms\OraclePlatform',
-            'sqlserver' => 'Doctrine\DBAL\Platforms\SQLServerPlatform',
-            'mariadb' => 'Doctrine\DBAL\Platforms\MariaDBPlatform',
-        ];
+        'postgresql' => 'Doctrine\DBAL\Platforms\PostgreSQLPlatform',
+        'mysql' => 'Doctrine\DBAL\Platforms\MySQLPlatform',
+        'sqlite' => 'Doctrine\DBAL\Platforms\SqlitePlatform',
+        'oracle' => 'Doctrine\DBAL\Platforms\OraclePlatform',
+        'mssql' => 'Doctrine\DBAL\Platforms\SQLServerPlatform',
+        'db2' => 'Doctrine\DBAL\Platforms\DB2Platform',
+    ];
 
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Change $platform->getName() === "postgresql" to $platform instanceof PostgreSQLPlatform',
+            'Change $platform->getName() === "postgresql" to $platform instanceof PostgreSQLPlatform, following the DBAL 3.2 deprecation of AbstractPlatform::getName(), see https://github.com/doctrine/dbal/pull/4755',
             [
                 new CodeSample(
                     "if ('postgresql' === \$this->platform->getName()) {}",

--- a/rules/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector.php
+++ b/rules/Dbal32/Rector/Identical/PlatformGetNameToInstanceofRector.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Dbal32\Rector\Identical;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Equal;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://github.com/doctrine/dbal/pull/4755
+ * @see Rector\Doctrine\Tests\Dbal32\Rector\Identical\PlatformGetNameToInstanceofRector\PlatformGetNameToInstanceofRectorTest
+ */
+final class PlatformGetNameToInstanceofRector extends AbstractRector implements ComposerPackageConstraintInterface
+{
+    private const array PLATFORM_MAP = [
+            'postgresql' => 'Doctrine\DBAL\Platforms\PostgreSQLPlatform',
+            'mysql' => 'Doctrine\DBAL\Platforms\MySQLPlatform',
+            'sqlite' => 'Doctrine\DBAL\Platforms\SqlitePlatform',
+            'oracle' => 'Doctrine\DBAL\Platforms\OraclePlatform',
+            'sqlserver' => 'Doctrine\DBAL\Platforms\SQLServerPlatform',
+            'mariadb' => 'Doctrine\DBAL\Platforms\MariaDBPlatform',
+        ];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Change $platform->getName() === "postgresql" to $platform instanceof PostgreSQLPlatform',
+            [
+                new CodeSample(
+                    "if ('postgresql' === \$this->platform->getName()) {}",
+                    "if (\$this->platform instanceof \Doctrine\DBAL\Platforms\PostgreSQLPlatform) {}"
+                ),
+            ]
+        );
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('doctrine/dbal', '>= 3.2');
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Identical::class, Equal::class];
+    }
+
+    /**
+     * @param Identical|Equal $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        // Handle both: 'postgresql' === $platform->getName() AND $platform->getName() === 'postgresql'
+        if ($node->left instanceof String_ && $node->right instanceof MethodCall) {
+            $stringNode = $node->left;
+            $methodCallNode = $node->right;
+        } elseif ($node->right instanceof String_ && $node->left instanceof MethodCall) {
+            $stringNode = $node->right;
+            $methodCallNode = $node->left;
+        } else {
+            return null;
+        }
+
+        if (! $this->isName($methodCallNode->name, 'getName')) {
+            return null;
+        }
+
+        // ONLY apply this if the variable calling getName() is a Doctrine DBAL Platform
+        if (! $this->isObjectType($methodCallNode->var, new ObjectType('Doctrine\DBAL\Platforms\AbstractPlatform'))) {
+            return null;
+        }
+
+        $platformName = $stringNode->value;
+        if (! isset(self::PLATFORM_MAP[$platformName])) {
+            return null;
+        }
+
+        return new Instanceof_(
+            $methodCallNode->var,
+            new FullyQualified(self::PLATFORM_MAP[$platformName])
+        );
+    }
+}


### PR DESCRIPTION
Adds `PlatformGetNameToInstanceofRector` for the DBAL 3.2 deprecation of `AbstractPlatform::getName()` ([doctrine/dbal#4755](https://github.com/doctrine/dbal/pull/4755)).

String comparisons against `getName()` become `instanceof` checks against the concrete platform class:

```diff
 use Doctrine\DBAL\Platforms\AbstractPlatform;

 function run(AbstractPlatform $platform): void
 {
-    if ('postgresql' === $platform->getName()) {
+    if ($platform instanceof \Doctrine\DBAL\Platforms\PostgreSQLPlatform) {
     }

-    if ($platform->getName() === 'mysql') {
+    if ($platform instanceof \Doctrine\DBAL\Platforms\MySQLPlatform) {
     }
 }
```

Handles both operand orders and `===`/`==`. Only fires when the receiver is typed as `Doctrine\DBAL\Platforms\AbstractPlatform`, so unrelated `getName()` calls are left alone.

Platform map uses the actual `getName()` return strings: `postgresql`, `mysql`, `sqlite`, `oracle`, `mssql` (SQL Server), `db2`. Unknown strings are skipped.