### PR TITLE
Run cheap guards before expensive analysis calls

### DIFF
--- a/rules/Dbal211/Rector/MethodCall/ExtractArrayArgOnQueryBuilderSelectRector.php
+++ b/rules/Dbal211/Rector/MethodCall/ExtractArrayArgOnQueryBuilderSelectRector.php
@@ -67,6 +67,14 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?MethodCall
     {
+        if (! $this->isNames($node->name, ['select', 'addSelect', 'groupBy', 'addGroupBy'])) {
+            return null;
+        }
+
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         $varType = $this->nodeTypeResolver->getType($node->var);
 
         if (! $varType instanceof ObjectType) {
@@ -74,14 +82,6 @@ CODE_SAMPLE
         }
 
         if (! $varType->isInstanceOf(DoctrineClass::DBAL_QUERY_BUILDER)->yes()) {
-            return null;
-        }
-
-        if (! $this->isNames($node->name, ['select', 'addSelect', 'groupBy', 'addGroupBy'])) {
-            return null;
-        }
-
-        if ($node->isFirstClassCallable()) {
             return null;
         }
 

--- a/rules/Dbal36/Rector/MethodCall/MigrateQueryBuilderResetQueryPartRector.php
+++ b/rules/Dbal36/Rector/MethodCall/MigrateQueryBuilderResetQueryPartRector.php
@@ -89,11 +89,11 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isObjectType($node->var, new ObjectType(DoctrineClass::DBAL_QUERY_BUILDER))) {
+        if (! $this->isName($node->name, 'resetQueryPart')) {
             return null;
         }
 
-        if (! $this->isName($node->name, 'resetQueryPart')) {
+        if (! $this->isObjectType($node->var, new ObjectType(DoctrineClass::DBAL_QUERY_BUILDER))) {
             return null;
         }
 

--- a/rules/Dbal40/Rector/MethodCall/ChangeCompositeExpressionAddMultipleWithWithRector.php
+++ b/rules/Dbal40/Rector/MethodCall/ChangeCompositeExpressionAddMultipleWithWithRector.php
@@ -81,14 +81,14 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         if (! $this->nodeTypeResolver->isObjectType(
             $node->var,
             new ObjectType(DoctrineClass::COMPOSITE_EXPRESSION)
         )) {
-            return null;
-        }
-
-        if ($node->isFirstClassCallable()) {
             return null;
         }
 

--- a/rules/Orm28/Rector/MethodCall/IterateToToIterableRector.php
+++ b/rules/Orm28/Rector/MethodCall/IterateToToIterableRector.php
@@ -96,6 +96,11 @@ CODE_SAMPLE
             return $this->refactorForeach($node);
         }
 
+        // Change iterate() method calls to toIterable()
+        if (! $this->isName($node->name, 'iterate')) {
+            return null;
+        }
+
         $varType = $this->nodeTypeResolver->getType($node->var);
 
         if (! $varType instanceof ObjectType) {
@@ -103,11 +108,6 @@ CODE_SAMPLE
         }
 
         if (! $varType->isInstanceOf(DoctrineClass::ABSTRACT_QUERY)->yes()) {
-            return null;
-        }
-
-        // Change iterate() method calls to toIterable()
-        if (! $this->isName($node->name, 'iterate')) {
             return null;
         }
 

--- a/rules/Orm30/Rector/MethodCall/SetParametersArrayToCollectionRector.php
+++ b/rules/Orm30/Rector/MethodCall/SetParametersArrayToCollectionRector.php
@@ -175,6 +175,14 @@ final class SetParametersArrayToCollectionRector extends AbstractRector implemen
 
     private function refactorMethodCall(MethodCall $methodCall): Node|null
     {
+        if ($methodCall->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (! $this->isNames($methodCall->name, ['setParameters'])) {
+            return null;
+        }
+
         $varType = $this->nodeTypeResolver->getType($methodCall->var);
 
         if (! $varType instanceof ObjectType) {
@@ -182,14 +190,6 @@ final class SetParametersArrayToCollectionRector extends AbstractRector implemen
         }
 
         if (! $varType->isInstanceOf('Doctrine\\ORM\\QueryBuilder')->yes()) {
-            return null;
-        }
-
-        if ($methodCall->isFirstClassCallable()) {
-            return null;
-        }
-
-        if (! $this->isNames($methodCall->name, ['setParameters'])) {
             return null;
         }
 


### PR DESCRIPTION
symplify/phpstan-rules 14.13.0 adds `RectorCheaperGuardsFirstRule`, which flags a cheap early-return guard (`isName()`, `isNames()`, `isFirstClassCallable()`, ...) that runs after an expensive analysis call (`getType()`, `isObjectType()`, ...) when the cheap guard does not depend on the expensive call's result.

This reorders 5 rules so the cheap, independent guards run first and short-circuit before the expensive type resolution:

- Dbal211 `ExtractArrayArgOnQueryBuilderSelectRector`
- Dbal36 `MigrateQueryBuilderResetQueryPartRector`
- Dbal40 `ChangeCompositeExpressionAddMultipleWithWithRector`
- Orm28 `IterateToToIterableRector`
- Orm30 `SetParametersArrayToCollectionRector`

Behavior-preserving: all guards only `return null`, so their relative order does not change the result. PHPStan, ECS, and the affected rule tests pass.