### PR TITLE
[CodeQuality] Skip TypedPropertyFromToOneRelationTypeRector on untyped parent property override

### DIFF
--- a/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromToOneRelationTypeRector/Fixture/skip_untyped_parent_trait_property.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromToOneRelationTypeRector/Fixture/skip_untyped_parent_trait_property.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromToOneRelationTypeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromToOneRelationTypeRector\Source\AbstractBaseWithTraitEntity;
+
+class SkipUntypedParentTraitProperty extends AbstractBaseWithTraitEntity
+{
+    /**
+     * @ORM\OneToOne(targetEntity="Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromToOneRelationTypeRector\Source\Company")
+     */
+    protected $company;
+}

--- a/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromToOneRelationTypeRector/Source/AbstractBaseWithTraitEntity.php
+++ b/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromToOneRelationTypeRector/Source/AbstractBaseWithTraitEntity.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromToOneRelationTypeRector\Source;
+
+abstract class AbstractBaseWithTraitEntity
+{
+    use UntypedRelationTrait;
+}

--- a/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromToOneRelationTypeRector/Source/UntypedRelationTrait.php
+++ b/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromToOneRelationTypeRector/Source/UntypedRelationTrait.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromToOneRelationTypeRector\Source;
+
+trait UntypedRelationTrait
+{
+    protected $company;
+}

--- a/rules/CodeQuality/Rector/Property/TypedPropertyFromToOneRelationTypeRector.php
+++ b/rules/CodeQuality/Rector/Property/TypedPropertyFromToOneRelationTypeRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\ComplexType;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
@@ -18,6 +19,7 @@ use Rector\Doctrine\NodeManipulator\ToOneRelationPropertyTypeResolver;
 use Rector\Php\PhpVersionProvider;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\TypeDeclaration\NodeTypeAnalyzer\PropertyTypeDecorator;
 use Rector\ValueObject\PhpVersion;
@@ -38,6 +40,7 @@ final class TypedPropertyFromToOneRelationTypeRector extends AbstractRector impl
         private readonly PhpVersionProvider $phpVersionProvider,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly ReflectionResolver $reflectionResolver,
     ) {
     }
 
@@ -94,6 +97,12 @@ CODE_SAMPLE
             return null;
         }
 
+        // avoid untyped parent property override, e.g. from a trait used in a parent class
+        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        if ($classReflection instanceof ClassReflection && $this->hasUntypedParentProperty($classReflection, $node)) {
+            return null;
+        }
+
         $propertyType = $this->toOneRelationPropertyTypeResolver->resolve($node);
         if (! $propertyType instanceof Type) {
             return null;
@@ -110,6 +119,24 @@ CODE_SAMPLE
 
         $this->completePropertyTypeOrVarDoc($propertyType, $typeNode, $node);
         return $node;
+    }
+
+    private function hasUntypedParentProperty(ClassReflection $classReflection, Property $property): bool
+    {
+        $propertyName = $this->getName($property);
+
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            $nativeReflectionClass = $parentClassReflection->getNativeReflection();
+            if (! $nativeReflectionClass->hasProperty($propertyName)) {
+                continue;
+            }
+
+            // typing the child while the parent property stays untyped is a fatal error
+            return $nativeReflectionClass->getProperty($propertyName)
+                ->getType() === null;
+        }
+
+        return false;
     }
 
     public function provideMinPhpVersion(): int

--- a/rules/Collection22/Rector/CriteriaOrderingConstantsDeprecationRector.php
+++ b/rules/Collection22/Rector/CriteriaOrderingConstantsDeprecationRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\Collection22\Rector;
 
+use PHPStan\Type\IsSuperTypeOfResult;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\ArrayItem;
@@ -174,7 +175,7 @@ final class CriteriaOrderingConstantsDeprecationRector extends AbstractRector im
                 $item->value instanceof ClassConstFetch
                 && $item->value->class instanceof Name
                 /* @phpstan-ignore-next-line */
-                && $this->criteriaObjectType->isSuperTypeOf(new ObjectType($item->value->class->toString()))
+                && $this->criteriaObjectType->isSuperTypeOf(new ObjectType($item->value->class->toString())) instanceof IsSuperTypeOfResult
                 && $item->value->name instanceof Identifier
                 && in_array($v = strtoupper((string) $item->value->name), ['ASC', 'DESC'], true)
             ) {


### PR DESCRIPTION
Fixes rectorphp/rector#9892

When a to-one relation property is redeclared in a child class while the parent class (often via a trait) declares the same property untyped, PHP forbids narrowing the type only on the child:

```
Fatal error: Type of Foo::$client must not be defined (as in class BaseFoo)
```

The rule now resolves the class and walks its parents. If a parent declares the same property with no native type, the property is left untouched. Own docblock-based typing (e.g. non-existent `@var` targets) is unaffected - only the parent-override case is guarded.

Added a skip fixture with a parent class pulling the property from a trait.