### PR TITLE
[CodeQuality] Skip TypedPropertyFromColumnTypeRector on untyped parent property override

### DIFF
--- a/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector/Fixture/skip_untyped_grand_parent_column_property.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector/Fixture/skip_untyped_grand_parent_column_property.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromColumnTypeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromColumnTypeRector\Source\AbstractParentScopeEntity;
+
+class SkipUntypedGrandParentColumnProperty extends AbstractParentScopeEntity
+{
+    /**
+     * @ORM\Column(type="string")
+     */
+    protected $scopes;
+}

--- a/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector/Source/AbstractGrandParentScopeEntity.php
+++ b/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector/Source/AbstractGrandParentScopeEntity.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromColumnTypeRector\Source;
+
+abstract class AbstractGrandParentScopeEntity
+{
+    protected $scopes;
+}

--- a/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector/Source/AbstractParentScopeEntity.php
+++ b/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector/Source/AbstractParentScopeEntity.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromColumnTypeRector\Source;
+
+abstract class AbstractParentScopeEntity extends AbstractGrandParentScopeEntity
+{
+}

--- a/rules/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector.php
+++ b/rules/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector.php
@@ -6,6 +6,7 @@ namespace Rector\Doctrine\CodeQuality\Rector\Property;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -15,6 +16,7 @@ use Rector\Doctrine\NodeManipulator\ColumnPropertyTypeResolver;
 use Rector\Doctrine\NodeManipulator\NullabilityColumnPropertyTypeResolver;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\TypeDeclaration\NodeTypeAnalyzer\PropertyTypeDecorator;
 use Rector\ValueObject\PhpVersionFeature;
@@ -33,6 +35,7 @@ final class TypedPropertyFromColumnTypeRector extends AbstractRector implements 
         private readonly NullabilityColumnPropertyTypeResolver $nullabilityColumnPropertyTypeResolver,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly ReflectionResolver $reflectionResolver,
     ) {
     }
 
@@ -84,6 +87,12 @@ CODE_SAMPLE
             return null;
         }
 
+        // avoid untyped parent property override, that would be a fatal error
+        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        if ($classReflection instanceof ClassReflection && $this->hasUntypedParentProperty($classReflection, $node)) {
+            return null;
+        }
+
         $isNullable = $this->nullabilityColumnPropertyTypeResolver->isNullable($node);
 
         $propertyType = $this->columnPropertyTypeResolver->resolve($node, $isNullable);
@@ -110,6 +119,24 @@ CODE_SAMPLE
 
         $node->type = $typeNode;
         return $node;
+    }
+
+    private function hasUntypedParentProperty(ClassReflection $classReflection, Property $property): bool
+    {
+        $propertyName = $this->getName($property);
+
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            $nativeReflectionClass = $parentClassReflection->getNativeReflection();
+            if (! $nativeReflectionClass->hasProperty($propertyName)) {
+                continue;
+            }
+
+            // typing the child while the parent property stays untyped is a fatal error
+            return $nativeReflectionClass->getProperty($propertyName)
+                ->getType() === null;
+        }
+
+        return false;
     }
 
     public function provideMinPhpVersion(): int


### PR DESCRIPTION
Reported in rectorphp/rector#9893.

`TypedPropertyFromColumnTypeRector` added a native type to a `@ORM\Column` property even when an ancestor class (parent or grandparent) declared the same property untyped. That produces a fatal error:

> Type of ...::\$scopes must not be defined (as in class ...Base\BaseScopeConverterEntity)

because a redeclared property must keep the exact type of its ancestor, and an untyped ancestor property forbids a type on the child.

The rule now resolves the class and bails out when any parent declares the property without a type. Mirrors the same guard added for `TypedPropertyFromToOneRelationTypeRector` in #520.

Covered by a skip fixture with a grandparent chain.

Fixes rectorphp/rector#9893

https://claude.ai/code/session_012tDVpmbVs1w1nyEVbq7LMa