### PR TITLE
[CodeQuality] Fix TypedPropertyFromColumnTypeRector numeric default on decimal/bigint

### DIFF
--- a/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector/Fixture/decimal_default_value.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector/Fixture/decimal_default_value.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromColumnTypeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class DecimalDefaultValue
+{
+    /**
+     * @ORM\Column(type="decimal", precision=10, scale=2, nullable=false)
+     */
+    private $totalShippingCostDec = 0;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromColumnTypeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class DecimalDefaultValue
+{
+    /**
+     * @ORM\Column(type="decimal", precision=10, scale=2, nullable=false)
+     */
+    private string $totalShippingCostDec = '0';
+}
+
+?>

--- a/rules/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector.php
+++ b/rules/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Rector\Doctrine\CodeQuality\Rector\Property;
 
 use PhpParser\Node;
+use PhpParser\Node\Scalar\Float_;
+use PhpParser\Node\Scalar\Int_;
+use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
@@ -112,6 +116,9 @@ CODE_SAMPLE
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
+        // Doctrine "decimal"/"bigint" map to string; keep a numeric default valid as string, eg: 0 to '0'
+        $this->refactorNumericDefaultToString($node, $propertyType);
+
         if ($propertyType instanceof UnionType) {
             $this->propertyTypeDecorator->decoratePropertyUnionType($propertyType, $typeNode, $node, $phpDocInfo);
             return $node;
@@ -119,6 +126,22 @@ CODE_SAMPLE
 
         $node->type = $typeNode;
         return $node;
+    }
+
+    private function refactorNumericDefaultToString(Property $property, Type $propertyType): void
+    {
+        $bareType = TypeCombinator::removeNull($propertyType);
+        if (! $bareType instanceof StringType) {
+            return;
+        }
+
+        $propertyItem = $property->props[0];
+        $default = $propertyItem->default;
+        if (! $default instanceof Int_ && ! $default instanceof Float_) {
+            return;
+        }
+
+        $propertyItem->default = new String_((string) $default->value);
     }
 
     private function hasUntypedParentProperty(ClassReflection $classReflection, Property $property): bool


### PR DESCRIPTION
Doctrine `decimal` and `bigint` map to a PHP `string` (see [Doctrine basic mapping](https://www.doctrine-project.org/projects/doctrine-orm/en/2.16/reference/basic-mapping.html)).

When such a property has a numeric default, the rule set the `string` type but left the int default, producing a fatal error:

> Cannot use int as default value for property ... of type string

Now the numeric default is converted to its string form:

```diff
-private $totalShippingCostDec = 0;
+private string $totalShippingCostDec = '0';
```

Fixes rectorphp/rector#9894

https://claude.ai/code/session_018nXn7xBmuX9jrY8zZqgAxp