### PR TITLE
[CodeQuality] Make property nullable when null default present in TypedPropertyFromColumnTypeRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector/Fixture/null_default_forces_nullable_object.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector/Fixture/null_default_forces_nullable_object.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromColumnTypeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class NullDefaultForcesNullableObject
+{
+    /**
+     * @ORM\Column(type="datetime", nullable=false)
+     */
+    private $historyDate = null;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromColumnTypeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class NullDefaultForcesNullableObject
+{
+    /**
+     * @ORM\Column(type="datetime", nullable=false)
+     */
+    private ?\DateTimeInterface $historyDate = null;
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector/Fixture/null_default_forces_nullable_scalar.php.inc
+++ b/rules-tests/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector/Fixture/null_default_forces_nullable_scalar.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromColumnTypeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class NullDefaultForcesNullableScalar
+{
+    /**
+     * @ORM\Column(type="string", nullable=false)
+     */
+    private $surname = null;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\CodeQuality\Rector\Property\TypedPropertyFromColumnTypeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class NullDefaultForcesNullableScalar
+{
+    /**
+     * @ORM\Column(type="string", nullable=false)
+     */
+    private ?string $surname = null;
+}
+
+?>

--- a/rules/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector.php
+++ b/rules/CodeQuality/Rector/Property/TypedPropertyFromColumnTypeRector.php
@@ -18,6 +18,7 @@ use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Doctrine\NodeManipulator\ColumnPropertyTypeResolver;
 use Rector\Doctrine\NodeManipulator\NullabilityColumnPropertyTypeResolver;
+use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
 use Rector\Reflection\ReflectionResolver;
@@ -40,6 +41,7 @@ final class TypedPropertyFromColumnTypeRector extends AbstractRector implements 
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly ReflectionResolver $reflectionResolver,
+        private readonly ValueResolver $valueResolver,
     ) {
     }
 
@@ -104,8 +106,8 @@ CODE_SAMPLE
             return null;
         }
 
-        // add default null if missing
-        if ($isNullable && ! TypeCombinator::containsNull($propertyType)) {
+        // a null default forces a nullable type, regardless of the column nullability
+        if (($isNullable || $this->hasNullDefault($node)) && ! TypeCombinator::containsNull($propertyType)) {
             $propertyType = TypeCombinator::addNull($propertyType);
         }
 
@@ -142,6 +144,16 @@ CODE_SAMPLE
         }
 
         $propertyItem->default = new String_((string) $default->value);
+    }
+
+    private function hasNullDefault(Property $property): bool
+    {
+        $default = $property->props[0]->default;
+        if ($default === null) {
+            return false;
+        }
+
+        return $this->valueResolver->isNull($default);
     }
 
     private function hasUntypedParentProperty(ClassReflection $classReflection, Property $property): bool


### PR DESCRIPTION
A property with a `= null` default must be nullable. When `TypedPropertyFromColumnTypeRector` typed such a property from a `nullable=false` column, it produced a non-nullable type with a `= null` default - a fatal error.

The default is the source of truth here: if a property defaults to `null`, the resolved type is made nullable regardless of the column mapping. The default value is left untouched.

```diff
 /**
  * @ORM\Column(type="datetime", nullable=false)
  */
-private $historyDate = null;
+private ?\DateTimeInterface $historyDate = null;
```

Fixes rectorphp/rector#9896
